### PR TITLE
Docs: add llms.txt content guide

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,33 @@
+# Leon Cheng
+
+> Leon Cheng's personal website, with writing about AI, engineering workflows, developer tools, products, and side projects.
+
+## Reading blog articles
+
+Blog pages on leoncheng.dev are client-rendered and may return an HTTP 404 to clients that do not execute JavaScript. The canonical, machine-readable article content is public Markdown in the GitHub repository.
+
+- [Blog Markdown directory](https://github.com/leoncheng57/leoncheng57.github.io/tree/main/src/content/blog)
+- [Repository](https://github.com/leoncheng57/leoncheng57.github.io)
+
+Each blog URL slug matches its Markdown filename. To read an article, replace `{slug}` in this URL:
+
+`https://raw.githubusercontent.com/leoncheng57/leoncheng57.github.io/main/src/content/blog/{slug}.md`
+
+For example, `/blog/the-ticket-is-the-interface` is available as:
+
+- [The Ticket Is the Interface](https://raw.githubusercontent.com/leoncheng57/leoncheng57.github.io/main/src/content/blog/the-ticket-is-the-interface.md)
+
+The Markdown frontmatter contains the article title, description, publication date, and tags. Treat the Markdown source as authoritative when the rendered website and repository differ.
+
+## Recent articles
+
+- [My cmux Setup for Parallel AI Coding](https://raw.githubusercontent.com/leoncheng57/leoncheng57.github.io/main/src/content/blog/my-cmux-setup-for-parallel-ai-coding.md)
+- [The Ticket Is the Interface: A Better Way to Work With AI](https://raw.githubusercontent.com/leoncheng57/leoncheng57.github.io/main/src/content/blog/the-ticket-is-the-interface.md)
+- [Hindsight Memory: Auto-Updating RAG for Agents](https://raw.githubusercontent.com/leoncheng57/leoncheng57.github.io/main/src/content/blog/hindsight-memory.md)
+- [Agentic Chaining: Small Opinionated Agents in a Line](https://raw.githubusercontent.com/leoncheng57/leoncheng57.github.io/main/src/content/blog/agentic-chaining.md)
+
+## Website
+
+- [Home](https://leoncheng.dev/)
+- [Blog](https://leoncheng.dev/blog)
+- [Apps](https://leoncheng.dev/apps)

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,33 @@
+# Leon Cheng
+
+> Leon Cheng's personal website, with writing about AI, engineering workflows, developer tools, products, and side projects.
+
+## Reading blog articles
+
+Blog pages on leoncheng.dev are client-rendered and may return an HTTP 404 to clients that do not execute JavaScript. The canonical, machine-readable article content is public Markdown in the GitHub repository.
+
+- [Blog Markdown directory](https://github.com/leoncheng57/leoncheng57.github.io/tree/main/src/content/blog)
+- [Repository](https://github.com/leoncheng57/leoncheng57.github.io)
+
+Each blog URL slug matches its Markdown filename. To read an article, replace `{slug}` in this URL:
+
+`https://raw.githubusercontent.com/leoncheng57/leoncheng57.github.io/main/src/content/blog/{slug}.md`
+
+For example, `/blog/the-ticket-is-the-interface` is available as:
+
+- [The Ticket Is the Interface](https://raw.githubusercontent.com/leoncheng57/leoncheng57.github.io/main/src/content/blog/the-ticket-is-the-interface.md)
+
+The Markdown frontmatter contains the article title, description, publication date, and tags. Treat the Markdown source as authoritative when the rendered website and repository differ.
+
+## Recent articles
+
+- [My cmux Setup for Parallel AI Coding](https://raw.githubusercontent.com/leoncheng57/leoncheng57.github.io/main/src/content/blog/my-cmux-setup-for-parallel-ai-coding.md)
+- [The Ticket Is the Interface: A Better Way to Work With AI](https://raw.githubusercontent.com/leoncheng57/leoncheng57.github.io/main/src/content/blog/the-ticket-is-the-interface.md)
+- [Hindsight Memory: Auto-Updating RAG for Agents](https://raw.githubusercontent.com/leoncheng57/leoncheng57.github.io/main/src/content/blog/hindsight-memory.md)
+- [Agentic Chaining: Small Opinionated Agents in a Line](https://raw.githubusercontent.com/leoncheng57/leoncheng57.github.io/main/src/content/blog/agentic-chaining.md)
+
+## Website
+
+- [Home](https://leoncheng.dev/)
+- [Blog](https://leoncheng.dev/blog)
+- [Apps](https://leoncheng.dev/apps)


### PR DESCRIPTION
## Summary
- publish `/llms.txt` for agents and non-JavaScript clients
- explain that SPA blog routes may return HTTP 404 without client rendering
- point each blog slug to its canonical raw GitHub Markdown source
- include direct links to recent articles and repository content

## Verification
- `npm run build`
- fetched `http://127.0.0.1:5174/llms.txt` successfully
- verified the raw GitHub article URL returns the complete Markdown source