### PR TITLE
Add pull request CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test:run
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary
- run lint, tests, and a production build for every pull request
- run the same checks after pushes to main
- use read-only repository permissions and the npm lockfile cache

## Validation
- `npm run lint`
- `npm run test:run` (58 tests)
- `npm run build`

Part of #29. This lands first so the deployment and Development-page PRs are covered by repository CI.