### PR TITLE
Add GitHub Pages PR previews

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,47 @@
+name: Deploy production
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build production site
+        run: |
+          rm -rf docs
+          npm run build
+
+      - name: Deploy production site
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: docs
+          branch: gh-pages
+          clean: true
+          clean-exclude: |
+            previews
+            previews/**
+          force: false
+          attempt-limit: 10

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,109 @@
+name: PR preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: >-
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build preview
+        env:
+          PREVIEW_PATH: /previews/pr-${{ github.event.pull_request.number }}/
+        run: |
+          rm -rf docs
+          npx vite build --base="$PREVIEW_PATH"
+          cp docs/index.html docs/404.html
+
+      - name: Deploy preview
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: docs
+          branch: gh-pages
+          target-folder: previews/pr-${{ github.event.pull_request.number }}
+          clean: true
+          force: false
+          attempt-limit: 10
+
+      - name: Add preview link to pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- pr-preview -->';
+            const previewUrl = `https://leoncheng.dev/previews/pr-${context.issue.number}/`;
+            const body = [
+              marker,
+              `PR preview: ${previewUrl}`,
+              '',
+              '_Updated for the latest commit. This preview is removed when the pull request closes._',
+            ].join('\n');
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+  cleanup:
+    if: >-
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Create empty deployment directory
+        run: mkdir preview-cleanup
+
+      - name: Remove preview
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: preview-cleanup
+          branch: gh-pages
+          target-folder: previews/pr-${{ github.event.pull_request.number }}
+          clean: true
+          force: false
+          attempt-limit: 10

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,4 +124,10 @@ EOF
 ## Deployment Note
 
 Vite is configured to build into `docs/` in `vite.config.ts`.
-If this repository is deployed via GitHub Pages, the published site content comes from that generated directory.
+GitHub Actions publishes that generated directory to the `gh-pages` branch:
+
+- `.github/workflows/deploy-production.yml` publishes production at the branch root and preserves `previews/`.
+- `.github/workflows/pr-preview.yml` publishes each pull request under `previews/pr-<number>/` and removes it when the pull request closes.
+- Both workflows must keep the shared `gh-pages-deploy` concurrency group and non-force pushes because they write to the same branch.
+
+GitHub Pages must publish from the `gh-pages` branch root. During the initial cutover, seed and verify the branch with the manual production workflow before changing the Pages source from `main:/docs`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Leon's Website
 
-My personal site, live at [leoncheng57.github.io](https://leoncheng57.github.io).
+My personal site, live at [leoncheng.dev](https://leoncheng.dev).
 
 A small home on the web for a short intro and the occasional blog post.
 
@@ -16,6 +16,45 @@ The homepage is an intentionally minimal landing page:
 
 ## Blog
 
-The blog lives at [`/blog`](https://leoncheng57.github.io/blog) and is where I write up things I've been thinking about — usually around software, developer tools, and how the craft of building software is changing.
+The blog lives at [`/blog`](https://leoncheng.dev/blog) and is where I write up things I've been thinking about — usually around software, developer tools, and how the craft of building software is changing.
 
-Posts are written in Markdown and kept in [`content/`](./content), one file per article.
+Posts are written in Markdown and kept in [`src/content/blog/`](./src/content/blog), one file per article.
+
+## Development
+
+Install dependencies and start Vite locally:
+
+```bash
+npm install
+npm run dev
+```
+
+Run the same validation used by pull-request CI:
+
+```bash
+npm run lint
+npm run test:run
+npm run build
+```
+
+## Deployment
+
+GitHub Actions owns production and preview deployments. The generated `docs/`
+directory is deployment input; source changes belong in `src/` and `public/`.
+
+- Pushes to `main` build the site at `/` and deploy it to the root of the
+  `gh-pages` branch.
+- Pull requests build with a PR-specific base path and deploy to
+  `gh-pages:/previews/pr-<number>/`.
+- The preview workflow posts `https://leoncheng.dev/previews/pr-<number>/` to
+  the pull request and removes that directory when the pull request closes.
+- Production deploys preserve the entire `previews/` subtree.
+
+GitHub Pages must use **Deploy from a branch**, with `gh-pages` and `/(root)`
+as its publishing source. Production and preview workflows share one
+`gh-pages-deploy` concurrency group and use non-force pushes so their commits
+cannot overwrite one another.
+
+For the initial migration from `main:/docs`, run the production deployment
+manually and verify `index.html`, `CNAME`, `.nojekyll`, and `assets/` exist on
+`gh-pages` before changing the Pages publishing source.

--- a/src/features/workout-lab/components/WorkoutLabPwa.tsx
+++ b/src/features/workout-lab/components/WorkoutLabPwa.tsx
@@ -60,7 +60,11 @@ export default function WorkoutLabPwa(): ReactElement | null {
     const elements = [manifest, themeColor, appleCapable, appleTitle, appleIcon]
     elements.forEach((element) => document.head.appendChild(element))
 
-    if (import.meta.env.PROD && 'serviceWorker' in navigator) {
+    if (
+      import.meta.env.PROD &&
+      import.meta.env.BASE_URL === '/' &&
+      'serviceWorker' in navigator
+    ) {
       void navigator.serviceWorker.register('/workout-lab/sw.js', {
         scope: '/workout-lab/',
       })

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,7 @@ import './styles/globals.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <App />
     </BrowserRouter>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- deploy production builds to the `gh-pages` branch while preserving live previews
- deploy each pull request under `/previews/pr-<number>/`, comment the URL, and clean it up on close
- make React Router base-path aware and avoid registering the production PWA service worker in previews
- document the deployment topology and zero-downtime cutover

## Validation
- workflow YAML syntax parsed successfully
- `npm run lint`
- `npm run test:run` (58 tests)
- preview build with `--base=/previews/pr-77/`; generated favicon, JS, and CSS URLs use the preview prefix

## Rollout
This PR is stacked on #76. After #76 merges, retarget this PR to `main`. The preview job may create `gh-pages`, but the preview URL remains inactive until this PR merges and the Pages publishing source is cut over using the documented sequence.

Part of #29.