### PR TITLE
Keep CNAME and .nojekyll out of PR preview deployments

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -42,6 +42,11 @@ jobs:
           rm -rf docs
           npx vite build --base="$PREVIEW_PATH"
           cp docs/index.html docs/404.html
+          # The deploy action never deletes files named CNAME or .nojekyll,
+          # so shipping them into a preview folder would make close-cleanup
+          # leave a permanent stale directory behind. They belong only at
+          # the gh-pages root, which the production deploy provides.
+          rm -f docs/CNAME docs/.nojekyll
 
       - name: Deploy preview
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
## Summary
The deploy action's rsync permanently excludes files named `CNAME` and `.nojekyll` from deletion. Because preview builds copied both into `previews/pr-<N>/`, every closed PR left a stale directory containing just those two files (observed for #77, #80, #90 — since removed from `gh-pages` manually).

This strips both files from the preview build output before deploying. They are only meaningful at the `gh-pages` root, which the production workflow owns.

## Validation
- workflow YAML parses
- this PR's own preview deploy exercises the changed step

Follow-up to #90 / #29.