### PR TITLE
ci: automated PR screenshots from description page list

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -55,6 +55,10 @@ jobs:
           branch: gh-pages
           target-folder: previews/pr-${{ github.event.pull_request.number }}
           clean: true
+          # The PR screenshots workflow publishes into screenshots/ inside this
+          # preview folder; preview redeploys must not delete it. The cleanup
+          # job below intentionally has no exclude so PR close removes it.
+          clean-exclude: screenshots/**
           force: false
           attempt-limit: 10
 

--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -1,0 +1,138 @@
+name: PR screenshots
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Writes to the same gh-pages branch as the production and preview deploys,
+# so it must share their concurrency group and never force-push.
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
+jobs:
+  screenshots:
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event.action != 'edited' || github.event.changes.body != null)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Parse screenshot paths from pull request description
+        id: parse
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body ?? '';
+            const match = body.match(/```screenshots\s*\n([\s\S]*?)```/);
+            const paths = [];
+
+            if (match) {
+              for (const rawLine of match[1].split('\n')) {
+                const line = rawLine.trim();
+                if (!line || line.startsWith('#')) {
+                  continue;
+                }
+                if (!line.startsWith('/') || /\s/.test(line)) {
+                  core.setFailed(`Invalid screenshot path "${line}". Paths must start with "/" and contain no whitespace.`);
+                  return;
+                }
+                paths.push(line);
+              }
+            }
+
+            core.setOutput('paths', paths.join(' '));
+            core.setOutput('has_paths', paths.length > 0 ? 'true' : 'false');
+            core.info(paths.length > 0 ? `Screenshot paths: ${paths.join(' ')}` : 'No ```screenshots block found in the pull request description.');
+
+      - name: Set up Node.js
+        if: steps.parse.outputs.has_paths == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        if: steps.parse.outputs.has_paths == 'true'
+        run: npm ci
+
+      - name: Install Playwright browser
+        if: steps.parse.outputs.has_paths == 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Build app
+        if: steps.parse.outputs.has_paths == 'true'
+        run: |
+          rm -rf docs
+          npm run build
+
+      - name: Capture screenshots
+        if: steps.parse.outputs.has_paths == 'true'
+        run: node scripts/ci-screenshots.mjs ${{ steps.parse.outputs.paths }}
+
+      - name: Publish screenshots to gh-pages
+        if: steps.parse.outputs.has_paths == 'true'
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: screenshot-output
+          branch: gh-pages
+          target-folder: previews/pr-${{ github.event.pull_request.number }}/screenshots
+          clean: true
+          force: false
+          attempt-limit: 10
+
+      - name: Update screenshots comment on pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- pr-screenshots -->';
+            const hasPaths = '${{ steps.parse.outputs.has_paths }}' === 'true';
+            const shortSha = context.payload.pull_request.head.sha.slice(0, 7);
+            const baseUrl = `https://leoncheng.dev/previews/pr-${context.issue.number}/screenshots`;
+
+            const lines = [marker, '## PR screenshots', ''];
+            if (hasPaths) {
+              const manifest = JSON.parse(fs.readFileSync('screenshot-output/manifest.json', 'utf8'));
+              for (const entry of manifest) {
+                lines.push(`### \`${entry.path}\``);
+                lines.push('');
+                lines.push(`![${entry.path}](${baseUrl}/${entry.file}?sha=${shortSha})`);
+                lines.push('');
+              }
+              lines.push(`_Captured at ${shortSha}. Screenshots refresh on every push and description edit, and are removed when the pull request closes._`);
+            } else {
+              lines.push('No screenshots requested. Add a ```screenshots fenced block with one page path per line to the pull request description to capture pages.');
+            }
+            const body = lines.join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else if (hasPaths) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # testing
 /coverage
+/screenshot-output
 
 # next.js
 /.next/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,43 @@ npm run build
 - Prefer fresh screenshots captured from the current local app state rather than reusing older assets.
 - If the screenshots need to be persisted for the PR/MR description, add only the minimal image assets required and link/embed those hosted GitHub URLs in the PR/MR body.
 
-### Playwright Screenshot Workflow
+### Automated PR Screenshots (preferred)
+
+CI can capture screenshots for you. Add a fenced `screenshots` block to the
+pull request description with one page path per line:
+
+````md
+```screenshots
+/blog
+/blog/some-article
+/workout-lab
+```
+````
+
+`.github/workflows/pr-screenshots.yml` runs on every PR open, push, and
+description edit. It builds the app, captures each listed path with
+Playwright (`scripts/ci-screenshots.mjs`), publishes the PNGs to `gh-pages`
+under `previews/pr-<number>/screenshots/`, and maintains a single sticky PR
+comment embedding the images. The images are removed automatically when the
+pull request closes.
+
+Rules for the block:
+
+- Paths must start with `/` and contain no whitespace.
+- Lines starting with `#` are treated as comments and ignored.
+- Removing the block (or all paths) updates the sticky comment to say no
+  screenshots are requested.
+
+To run the capture locally:
+
+```bash
+npm run build
+node scripts/ci-screenshots.mjs /blog /apps
+```
+
+Output lands in `screenshot-output/` (untracked).
+
+### Playwright Screenshot Workflow (manual fallback)
 
 1. Start the local app with:
 
@@ -128,6 +164,7 @@ GitHub Actions publishes that generated directory to the `gh-pages` branch:
 
 - `.github/workflows/deploy-production.yml` publishes production at the branch root and preserves `previews/`.
 - `.github/workflows/pr-preview.yml` publishes each pull request under `previews/pr-<number>/` and removes it when the pull request closes.
-- Both workflows must keep the shared `gh-pages-deploy` concurrency group and non-force pushes because they write to the same branch.
+- `.github/workflows/pr-screenshots.yml` publishes PR screenshots under `previews/pr-<number>/screenshots/`; the preview deploy excludes that folder from its clean step, and the preview cleanup removes it on close.
+- All three workflows must keep the shared `gh-pages-deploy` concurrency group and non-force pushes because they write to the same branch.
 
 GitHub Pages must publish from the `gh-pages` branch root. During the initial cutover, seed and verify the branch with the manual production workflow before changing the Pages source from `main:/docs`.

--- a/scripts/ci-screenshots.mjs
+++ b/scripts/ci-screenshots.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * Capture screenshots of app pages for pull request review.
+ *
+ * Usage:
+ *   npm run build
+ *   node scripts/ci-screenshots.mjs /blog /workout-lab
+ *
+ * Serves the built `docs/` directory with `vite preview`, then captures one
+ * PNG per provided page path into `screenshot-output/`. Output filenames are
+ * derived from the path: `/` -> `home.png`, `/blog/foo` -> `blog--foo.png`.
+ *
+ * Used by .github/workflows/pr-screenshots.yml, where the page paths come
+ * from a ```screenshots fenced block in the pull request description.
+ */
+
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { chromium } from 'playwright';
+import { preview } from 'vite';
+
+const OUTPUT_DIR = 'screenshot-output';
+const VIEWPORT = { width: 1280, height: 800 };
+const PORT = 4173;
+
+function normalizePath(rawPath) {
+  const trimmed = rawPath.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (!trimmed.startsWith('/')) {
+    throw new Error(`Page paths must start with "/": received "${trimmed}"`);
+  }
+  return trimmed;
+}
+
+function fileNameForPath(pagePath) {
+  const stripped = pagePath.replace(/^\/+|\/+$/g, '');
+  if (!stripped) {
+    return 'home';
+  }
+  return stripped
+    .split('/')
+    .map((segment) => segment.replace(/[^a-zA-Z0-9_-]+/g, '-'))
+    .join('--');
+}
+
+async function main() {
+  const pagePaths = process.argv
+    .slice(2)
+    .map(normalizePath)
+    .filter(Boolean);
+
+  if (pagePaths.length === 0) {
+    console.error('No page paths provided. Example: node scripts/ci-screenshots.mjs /blog /apps');
+    process.exitCode = 1;
+    return;
+  }
+
+  await rm(OUTPUT_DIR, { recursive: true, force: true });
+  await mkdir(OUTPUT_DIR, { recursive: true });
+
+  const server = await preview({
+    preview: { port: PORT, strictPort: true },
+  });
+  const baseUrl = `http://localhost:${PORT}`;
+
+  const browser = await chromium.launch();
+  const captured = [];
+
+  try {
+    const context = await browser.newContext({ viewport: VIEWPORT });
+    const page = await context.newPage();
+
+    for (const pagePath of pagePaths) {
+      const fileName = `${fileNameForPath(pagePath)}.png`;
+      const outputPath = path.join(OUTPUT_DIR, fileName);
+      console.log(`Capturing ${pagePath} -> ${outputPath}`);
+      await page.goto(`${baseUrl}${pagePath}`, { waitUntil: 'networkidle' });
+      await page.screenshot({ path: outputPath, fullPage: false });
+      captured.push({ path: pagePath, file: fileName });
+    }
+  } finally {
+    await browser.close();
+    await server.close();
+  }
+
+  const manifestPath = path.join(OUTPUT_DIR, 'manifest.json');
+  await writeFile(manifestPath, `${JSON.stringify(captured, null, 2)}\n`);
+  console.log(`Captured ${captured.length} screenshot(s); manifest at ${manifestPath}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Implements issue #82: a GitHub Action that builds the app, runs Playwright, and screenshots the pages listed in the PR description on every PR update.

- `scripts/ci-screenshots.mjs`: serves the built `docs/` with `vite preview` and captures one PNG per page path (1280x800, headless Chromium) into `screenshot-output/`.
- `.github/workflows/pr-screenshots.yml`: triggers on `opened`/`reopened`/`synchronize`/`edited` (same-repo PRs, body-change guard on edits), parses the fenced `screenshots` block below, publishes PNGs to `gh-pages` under `previews/pr-<n>/screenshots/`, and maintains a sticky comment embedding them with `?sha=` cache busting. Shares the `gh-pages-deploy` concurrency group.
- `.github/workflows/pr-preview.yml`: preview redeploys now `clean-exclude` the `screenshots/` subfolder; the existing close cleanup still removes everything.
- `AGENTS.md`: documents the convention; manual Playwright flow kept as fallback.

## Answers to #82

1. App in Actions: yes, static Vite build served in-job.
2. Playwright in Actions: yes, `npx playwright install --with-deps chromium` (already a devDependency on main).
3. Description-driven page list: yes, via the block below.
4. Trigger on all PR updates: yes, including description edits.

## Test plan

This PR exercises itself via the block below. Verify: workflow run succeeds, sticky comment appears with rendered images, images update on push/description edit, and `previews/pr-<n>/` disappears on close.

```screenshots
/
/blog
/workout-lab
```