### PR TITLE
Add Guides placeholder page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import BlogIndexRoute from './features/blog/routes/BlogIndexRoute'
 import BlogPostRoute from './features/blog/routes/BlogPostRoute'
 import GameNightsRoute from './features/game-nights/routes/GameNightsRoute'
 import GuidesRoute from './features/guides/routes/GuidesRoute'
+import AlphaProjsRoute from './features/repo/routes/AlphaProjsRoute'
 import CiRoute from './features/repo/routes/CiRoute'
 import PlanningRoute from './features/repo/routes/PlanningRoute'
 import PreviewsRoute from './features/repo/routes/PreviewsRoute'
@@ -38,6 +39,7 @@ export default function App(): ReactElement {
         />
         <Route path="/apps" element={<AppsIndexRoute />} />
         <Route path="/repo" element={<RepoRoute />} />
+        <Route path="/repo/alpha-projs" element={<AlphaProjsRoute />} />
         <Route path="/repo/ci" element={<CiRoute />} />
         <Route path="/repo/production" element={<ProductionRoute />} />
         <Route path="/repo/previews" element={<PreviewsRoute />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import GameNightsRoute from './features/game-nights/routes/GameNightsRoute'
 import GuidesRoute from './features/guides/routes/GuidesRoute'
 import AlphaProjsRoute from './features/repo/routes/AlphaProjsRoute'
 import CiRoute from './features/repo/routes/CiRoute'
+import GoogleAnalyticsRoute from './features/repo/routes/GoogleAnalyticsRoute'
 import PlanningRoute from './features/repo/routes/PlanningRoute'
 import PreviewsRoute from './features/repo/routes/PreviewsRoute'
 import ProductionRoute from './features/repo/routes/ProductionRoute'
@@ -41,6 +42,7 @@ export default function App(): ReactElement {
         <Route path="/repo" element={<RepoRoute />} />
         <Route path="/repo/alpha-projs" element={<AlphaProjsRoute />} />
         <Route path="/repo/ci" element={<CiRoute />} />
+        <Route path="/repo/google-analytics" element={<GoogleAnalyticsRoute />} />
         <Route path="/repo/production" element={<ProductionRoute />} />
         <Route path="/repo/previews" element={<PreviewsRoute />} />
         <Route path="/repo/planning" element={<PlanningRoute />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import SupportRoute from './features/apps/whoops-hoops/routes/SupportRoute'
 import BlogIndexRoute from './features/blog/routes/BlogIndexRoute'
 import BlogPostRoute from './features/blog/routes/BlogPostRoute'
 import GameNightsRoute from './features/game-nights/routes/GameNightsRoute'
+import GuidesRoute from './features/guides/routes/GuidesRoute'
 import CiRoute from './features/repo/routes/CiRoute'
 import PlanningRoute from './features/repo/routes/PlanningRoute'
 import PreviewsRoute from './features/repo/routes/PreviewsRoute'
@@ -25,6 +26,7 @@ export default function App(): ReactElement {
         <Route path="/" element={<HomeRoute />} />
         <Route path="/blog" element={<BlogIndexRoute />} />
         <Route path="/blog/:slug" element={<BlogPostRoute />} />
+        <Route path="/guides" element={<GuidesRoute />} />
         <Route
           path="/georgies-board-game-nights"
           element={<GameNightsRoute />}

--- a/src/components/top-nav/TopNav.tsx
+++ b/src/components/top-nav/TopNav.tsx
@@ -13,7 +13,10 @@ export default function TopNav(): ReactElement {
       <div className={styles.linksRow}>
         <Link to="/blog">Blogs</Link>
         <Link to="/apps">Apps</Link>
-        <Link to="/repo">Repo</Link>
+        <Link to="/guides">Guides</Link>
+        <Link to="/repo">
+          <span aria-hidden="true">📁</span> Repo
+        </Link>
       </div>
     </nav>
   )

--- a/src/components/top-nav/TopNav.tsx
+++ b/src/components/top-nav/TopNav.tsx
@@ -7,6 +7,7 @@ const REPO_PAGES = [
   { to: '/repo/production', label: 'Production deploys' },
   { to: '/repo/previews', label: 'Pull request previews' },
   { to: '/repo/planning', label: 'Project planning' },
+  { to: '/repo/google-analytics', label: 'Google Analytics' },
   { to: '/repo/alpha-projs', label: 'Alpha Projs' },
 ]
 

--- a/src/components/top-nav/TopNav.tsx
+++ b/src/components/top-nav/TopNav.tsx
@@ -2,6 +2,14 @@ import type { ReactElement } from 'react'
 import { Link } from 'react-router-dom'
 import styles from './top-nav.module.css'
 
+const REPO_PAGES = [
+  { to: '/repo/ci', label: 'CI checks' },
+  { to: '/repo/production', label: 'Production deploys' },
+  { to: '/repo/previews', label: 'Pull request previews' },
+  { to: '/repo/planning', label: 'Project planning' },
+  { to: '/repo/alpha-projs', label: 'Alpha Projs' },
+]
+
 export default function TopNav(): ReactElement {
   return (
     <nav aria-label="Primary" className={styles.nav}>
@@ -14,9 +22,33 @@ export default function TopNav(): ReactElement {
         <Link to="/blog">Blogs</Link>
         <Link to="/apps">Apps</Link>
         <Link to="/guides">Guides</Link>
-        <Link to="/repo">
-          <span aria-hidden="true">📁</span> Repo
-        </Link>
+        <div className={styles.repoMenu}>
+          <Link
+            to="/repo"
+            className={styles.repoTrigger}
+            aria-label="Repo"
+            title="Repo"
+          >
+            <svg
+              aria-hidden="true"
+              className={styles.wrenchIcon}
+              viewBox="0 0 24 24"
+            >
+              <path d="M22.4 4.2a6.5 6.5 0 0 1-8.1 8.1L6.6 20a2.8 2.8 0 1 1-4-4l7.7-7.7a6.5 6.5 0 0 1 8.1-8.1l-3.7 3.7.7 2.7 2.7.7 3.7-3.7.6.6ZM5.2 16.9a1.2 1.2 0 1 0 0 2.4 1.2 1.2 0 0 0 0-2.4Z" />
+            </svg>
+          </Link>
+          <div
+            className={styles.repoDropdown}
+            role="group"
+            aria-label="Repo pages"
+          >
+            {REPO_PAGES.map((page) => (
+              <Link key={page.to} to={page.to}>
+                {page.label}
+              </Link>
+            ))}
+          </div>
+        </div>
       </div>
     </nav>
   )

--- a/src/components/top-nav/top-nav.module.css
+++ b/src/components/top-nav/top-nav.module.css
@@ -50,7 +50,8 @@
   gap: 0;
 }
 
-.linksRow a {
+.linksRow > a,
+.repoTrigger {
   display: grid;
   place-items: center;
   min-width: 6rem;
@@ -62,9 +63,71 @@
   text-transform: uppercase;
 }
 
-.linksRow a:hover {
+.linksRow > a:hover,
+.repoTrigger:hover {
   color: var(--text-primary);
   background: var(--accent-strong);
+}
+
+.repoMenu {
+  position: relative;
+  display: flex;
+}
+
+.repoTrigger {
+  min-width: 4.25rem;
+  padding: 0 0.75rem;
+}
+
+.wrenchIcon {
+  width: 1.2rem;
+  height: 1.2rem;
+  fill: currentColor;
+}
+
+.repoDropdown {
+  position: absolute;
+  z-index: 10;
+  top: 100%;
+  right: -3px;
+  display: grid;
+  width: 17rem;
+  border: 3px solid var(--text-primary);
+  background: var(--surface);
+  box-shadow: 7px 7px 0 var(--text-primary);
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+}
+
+.repoMenu:hover .repoDropdown,
+.repoMenu:focus-within .repoDropdown,
+.repoTrigger:focus + .repoDropdown,
+.repoDropdown:focus-within {
+  opacity: 1;
+  pointer-events: auto;
+  visibility: visible;
+}
+
+.repoDropdown a {
+  padding: 0.85rem 1rem;
+  border-bottom: 2px solid var(--text-primary);
+  color: var(--link-color);
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.repoDropdown a:last-child {
+  border-bottom: 0;
+}
+
+.repoDropdown a:hover,
+.repoDropdown a:focus-visible {
+  color: var(--text-primary);
+  background: var(--accent-strong);
+  opacity: 1;
 }
 
 @media (max-width: 480px) {
@@ -87,10 +150,24 @@
     gap: 0;
   }
 
-  .linksRow a {
+  .linksRow > a,
+  .repoTrigger {
     min-width: 0;
     flex: 1;
     padding: 0 0.4rem;
     font-size: 0.58rem;
+  }
+
+  .repoMenu {
+    flex: 0 0 3.25rem;
+  }
+
+  .repoTrigger {
+    width: 100%;
+    padding: 0 0.35rem;
+  }
+
+  .repoDropdown {
+    width: min(17rem, calc(100vw - 2rem));
   }
 }

--- a/src/features/guides/routes/GuidesRoute.tsx
+++ b/src/features/guides/routes/GuidesRoute.tsx
@@ -1,0 +1,15 @@
+import type { ReactElement } from 'react'
+import TopNav from '../../../components/top-nav/TopNav'
+import styles from '../../../App.module.css'
+
+export default function GuidesRoute(): ReactElement {
+  return (
+    <div className={styles.container}>
+      <TopNav />
+      <main className={styles.main}>
+        <h1>Guides</h1>
+        <p>TBD</p>
+      </main>
+    </div>
+  )
+}

--- a/src/features/guides/routes/guides-route.test.tsx
+++ b/src/features/guides/routes/guides-route.test.tsx
@@ -22,6 +22,6 @@ describe('guides route', () => {
 
     const repoLink = screen.getByRole('link', { name: 'Repo' })
     expect(repoLink).toHaveAttribute('href', '/repo')
-    expect(repoLink).toHaveTextContent('📁 Repo')
+    expect(repoLink).toHaveAttribute('title', 'Repo')
   })
 })

--- a/src/features/guides/routes/guides-route.test.tsx
+++ b/src/features/guides/routes/guides-route.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import App from '../../../App'
+
+describe('guides route', () => {
+  it('renders the placeholder page and primary navigation', () => {
+    render(
+      <MemoryRouter initialEntries={['/guides']}>
+        <App />
+      </MemoryRouter>
+    )
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Guides' })
+    ).toBeInTheDocument()
+    expect(screen.getByText('TBD')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Guides' })).toHaveAttribute(
+      'href',
+      '/guides'
+    )
+
+    const repoLink = screen.getByRole('link', { name: 'Repo' })
+    expect(repoLink).toHaveAttribute('href', '/repo')
+    expect(repoLink).toHaveTextContent('📁 Repo')
+  })
+})

--- a/src/features/repo/repo.module.css
+++ b/src/features/repo/repo.module.css
@@ -1,5 +1,11 @@
 .page {
+  min-height: 100vh;
   padding: 2rem 1rem 5rem;
+  background-color: #eaf3f4;
+  background-image:
+    linear-gradient(rgba(16, 35, 61, 0.12) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(16, 35, 61, 0.12) 1px, transparent 1px);
+  background-size: 32px 32px;
 }
 
 .page a {
@@ -200,4 +206,110 @@
   margin-top: 2.5rem;
   color: var(--text-muted);
   font-size: 0.95rem;
+}
+
+.placeholderBanner {
+  position: relative;
+  max-width: 44rem;
+  overflow: hidden;
+  padding: clamp(1.5rem, 5vw, 2.5rem);
+  border: 3px solid var(--text-primary);
+  background-color: var(--accent-mid);
+  background-image: radial-gradient(rgba(16, 35, 61, 0.16) 1px, transparent 1px);
+  background-size: 18px 18px;
+  box-shadow: 9px 9px 0 var(--text-primary);
+}
+
+.placeholderStatus {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.statusDot {
+  width: 0.65rem;
+  height: 0.65rem;
+  border: 2px solid var(--text-primary);
+  border-radius: 50%;
+  background: #f7df71;
+}
+
+.placeholderBanner h2 {
+  max-width: 10ch;
+  margin: 0 0 0.85rem;
+  font-family: "Arial Black", Arial, sans-serif;
+  font-size: clamp(2rem, 6vw, 3.5rem);
+  letter-spacing: -0.06em;
+  line-height: 0.92;
+  text-transform: uppercase;
+}
+
+.placeholderBanner p {
+  max-width: 36rem;
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.7;
+}
+
+.placeholderFooter {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1.25rem;
+  margin-top: 2rem;
+}
+
+.comingSoon {
+  flex: none;
+  padding: 0.7rem 0.9rem;
+  border: 2px solid var(--text-primary);
+  background: var(--surface-raised);
+  box-shadow: 4px 4px 0 var(--text-primary);
+  font-size: 0.7rem;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.buildTrack {
+  display: grid;
+  width: min(100%, 20rem);
+  gap: 0.45rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  text-align: right;
+  text-transform: uppercase;
+}
+
+.buildTrack span {
+  height: 0.75rem;
+  border: 2px solid var(--text-primary);
+  background: repeating-linear-gradient(
+    90deg,
+    var(--link-color) 0 1.25rem,
+    transparent 1.25rem 1.65rem
+  );
+}
+
+@media (max-width: 560px) {
+  .placeholderFooter {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .comingSoon {
+    align-self: flex-start;
+  }
+
+  .buildTrack {
+    width: 100%;
+    text-align: left;
+  }
 }

--- a/src/features/repo/repo.module.css
+++ b/src/features/repo/repo.module.css
@@ -296,6 +296,33 @@
     var(--link-color) 0 1.25rem,
     transparent 1.25rem 1.65rem
   );
+  animation: build-track 0.9s linear infinite;
+}
+
+@keyframes build-track {
+  to {
+    background-position: 1.65rem 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .buildTrack span {
+    animation: none;
+  }
+}
+
+.steps {
+  display: grid;
+  gap: 0.75rem;
+  margin: 1.25rem 0 0;
+  padding-left: 1.4rem;
+  color: var(--text-muted);
+  line-height: 1.7;
+}
+
+.steps strong,
+.steps code {
+  color: var(--text-primary);
 }
 
 @media (max-width: 560px) {

--- a/src/features/repo/routes/AlphaProjsRoute.tsx
+++ b/src/features/repo/routes/AlphaProjsRoute.tsx
@@ -1,0 +1,44 @@
+import type { ReactElement } from 'react'
+import { Link } from 'react-router-dom'
+import TopNav from '../../../components/top-nav/TopNav'
+import styles from '../repo.module.css'
+
+export default function AlphaProjsRoute(): ReactElement {
+  return (
+    <div className={styles.page}>
+      <TopNav />
+      <main className={styles.content}>
+        <p className={styles.backLink}>
+          <Link to="/repo">Back to Repo</Link>
+        </p>
+
+        <header className={styles.pageHeader}>
+          <p className={styles.eyebrow}>Repo / alpha projs</p>
+          <h1>Alpha Projs</h1>
+        </header>
+
+        <section
+          className={styles.placeholderBanner}
+          aria-labelledby="alpha-placeholder-heading"
+        >
+          <div className={styles.placeholderStatus}>
+            <span className={styles.statusDot} aria-hidden="true" />
+            In progress
+          </div>
+          <h2 id="alpha-placeholder-heading">Still taking shape</h2>
+          <p>
+            Early projects and experiments are being assembled here. This space
+            will become a home for things still in alpha.
+          </p>
+          <div className={styles.placeholderFooter}>
+            <span className={styles.comingSoon}>Coming soon</span>
+            <div className={styles.buildTrack} aria-hidden="true">
+              <span />
+              <strong>Building the next thing</strong>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/src/features/repo/routes/GoogleAnalyticsRoute.tsx
+++ b/src/features/repo/routes/GoogleAnalyticsRoute.tsx
@@ -1,0 +1,69 @@
+import type { ReactElement } from 'react'
+import { Link } from 'react-router-dom'
+import TopNav from '../../../components/top-nav/TopNav'
+import styles from '../repo.module.css'
+
+export default function GoogleAnalyticsRoute(): ReactElement {
+  return (
+    <div className={styles.page}>
+      <TopNav />
+      <main className={styles.content}>
+        <p className={styles.backLink}>
+          <Link to="/repo">Back to Repo</Link>
+        </p>
+
+        <header className={styles.pageHeader}>
+          <p className={styles.eyebrow}>Repo / analytics</p>
+          <h1>Google Analytics</h1>
+          <p>
+            The site uses one Google Analytics 4 property to understand page
+            traffic across the main site and its apps.
+          </p>
+        </header>
+
+        <section className={styles.section} aria-labelledby="analytics-setup-heading">
+          <h2 id="analytics-setup-heading">Current setup</h2>
+          <p>
+            The global tag is loaded in <code>index.html</code> with measurement
+            ID <code>G-5MLNJQ7789</code>. Every route shares this property; feature
+            pages do not load separate analytics SDKs.
+          </p>
+          <p>
+            <a
+              href="https://analytics.google.com/analytics/web/"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Open Google Analytics
+            </a>{' '}
+            and select the GA4 property connected to that measurement ID.
+          </p>
+        </section>
+
+        <section className={styles.section} aria-labelledby="analytics-verify-heading">
+          <h2 id="analytics-verify-heading">Verify reporting</h2>
+          <ol className={styles.steps}>
+            <li>
+              Open <strong>Reports → Realtime</strong> in Google Analytics.
+            </li>
+            <li>Visit the page being tested in another tab or private window.</li>
+            <li>
+              Confirm a <code>page_view</code> appears with the expected page
+              path, device, and traffic source.
+            </li>
+          </ol>
+        </section>
+
+        <section className={styles.section} aria-labelledby="analytics-routing-heading">
+          <h2 id="analytics-routing-heading">Client-side navigation</h2>
+          <p>
+            React Router changes pages without a full document reload. GA4
+            Enhanced Measurement should have browser-history page views enabled.
+            If route changes do not appear in Realtime, add explicit{' '}
+            <code>page_view</code> events before relying on route-level reports.
+          </p>
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/src/features/repo/routes/RepoRoute.tsx
+++ b/src/features/repo/routes/RepoRoute.tsx
@@ -25,6 +25,11 @@ const SUBPAGES = [
     description: 'The open GitHub issues currently on the backlog.',
   },
   {
+    to: '/repo/google-analytics',
+    title: 'Google Analytics',
+    description: 'The site-wide GA4 setup and how to verify page views.',
+  },
+  {
     to: '/repo/alpha-projs',
     title: 'Alpha Projs',
     description: 'Early projects and experiments still taking shape.',

--- a/src/features/repo/routes/RepoRoute.tsx
+++ b/src/features/repo/routes/RepoRoute.tsx
@@ -24,6 +24,11 @@ const SUBPAGES = [
     title: 'Project planning',
     description: 'The open GitHub issues currently on the backlog.',
   },
+  {
+    to: '/repo/alpha-projs',
+    title: 'Alpha Projs',
+    description: 'Early projects and experiments still taking shape.',
+  },
 ]
 
 export default function RepoRoute(): ReactElement {

--- a/src/features/repo/routes/repo-routes.test.tsx
+++ b/src/features/repo/routes/repo-routes.test.tsx
@@ -31,6 +31,9 @@ describe('repo hub route', () => {
       within(subpageNav).getByRole('link', { name: /Project planning/ })
     ).toHaveAttribute('href', '/repo/planning')
     expect(
+      within(subpageNav).getByRole('link', { name: /Google Analytics/ })
+    ).toHaveAttribute('href', '/repo/google-analytics')
+    expect(
       within(subpageNav).getByRole('link', { name: /Alpha Projs/ })
     ).toHaveAttribute('href', '/repo/alpha-projs')
 
@@ -79,6 +82,9 @@ describe('repo hub route', () => {
       within(repoPages).getByText('Project planning').closest('a')
     ).toHaveAttribute('href', '/repo/planning')
     expect(
+      within(repoPages).getByText('Google Analytics').closest('a')
+    ).toHaveAttribute('href', '/repo/google-analytics')
+    expect(
       within(repoPages).getByText('Alpha Projs').closest('a')
     ).toHaveAttribute('href', '/repo/alpha-projs')
   })
@@ -97,6 +103,25 @@ describe('repo hub route', () => {
 })
 
 describe('repo subpages', () => {
+  it('documents Google Analytics at /repo/google-analytics', () => {
+    render(
+      <MemoryRouter initialEntries={['/repo/google-analytics']}>
+        <App />
+      </MemoryRouter>
+    )
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Google Analytics' })
+    ).toBeInTheDocument()
+    expect(screen.getByText('G-5MLNJQ7789')).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'Open Google Analytics' })
+    ).toHaveAttribute('href', 'https://analytics.google.com/analytics/web/')
+    expect(
+      screen.getByRole('link', { name: 'Back to Repo' })
+    ).toHaveAttribute('href', '/repo')
+  })
+
   it('renders Alpha Projs at /repo/alpha-projs', () => {
     render(
       <MemoryRouter initialEntries={['/repo/alpha-projs']}>

--- a/src/features/repo/routes/repo-routes.test.tsx
+++ b/src/features/repo/routes/repo-routes.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, expect, it } from 'vitest'
 import App from '../../../App'
@@ -17,18 +17,22 @@ describe('repo hub route', () => {
 
     const subpageNav = screen.getByRole('navigation', { name: 'Repo pages' })
     expect(subpageNav).toBeInTheDocument()
+    expect(within(subpageNav).getByRole('link', { name: /CI checks/ })).toHaveAttribute(
+      'href',
+      '/repo/ci'
+    )
     expect(
-      screen.getByRole('link', { name: /CI checks/ })
-    ).toHaveAttribute('href', '/repo/ci')
-    expect(
-      screen.getByRole('link', { name: /Production deploys/ })
+      within(subpageNav).getByRole('link', { name: /Production deploys/ })
     ).toHaveAttribute('href', '/repo/production')
     expect(
-      screen.getByRole('link', { name: /Pull request previews/ })
+      within(subpageNav).getByRole('link', { name: /Pull request previews/ })
     ).toHaveAttribute('href', '/repo/previews')
     expect(
-      screen.getByRole('link', { name: /Project planning/ })
+      within(subpageNav).getByRole('link', { name: /Project planning/ })
     ).toHaveAttribute('href', '/repo/planning')
+    expect(
+      within(subpageNav).getByRole('link', { name: /Alpha Projs/ })
+    ).toHaveAttribute('href', '/repo/alpha-projs')
 
     // The detailed content lives on the subpages, not the hub.
     expect(
@@ -39,7 +43,7 @@ describe('repo hub route', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('uses the logo as the home link and renders Repo in the nav', () => {
+  it('uses a wrench link for Repo and lists its pages in the primary nav', () => {
     render(
       <MemoryRouter initialEntries={['/repo']}>
         <App />
@@ -54,10 +58,29 @@ describe('repo hub route', () => {
     expect(
       screen.queryByRole('link', { name: 'Development' })
     ).not.toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Repo' })).toHaveAttribute(
+    const primaryNav = screen.getByRole('navigation', { name: 'Primary' })
+    expect(within(primaryNav).getByRole('link', { name: 'Repo' })).toHaveAttribute(
       'href',
       '/repo'
     )
+
+    const repoPages = within(primaryNav).getByLabelText('Repo pages')
+    expect(within(repoPages).getByText('CI checks').closest('a')).toHaveAttribute(
+      'href',
+      '/repo/ci'
+    )
+    expect(
+      within(repoPages).getByText('Production deploys').closest('a')
+    ).toHaveAttribute('href', '/repo/production')
+    expect(
+      within(repoPages).getByText('Pull request previews').closest('a')
+    ).toHaveAttribute('href', '/repo/previews')
+    expect(
+      within(repoPages).getByText('Project planning').closest('a')
+    ).toHaveAttribute('href', '/repo/planning')
+    expect(
+      within(repoPages).getByText('Alpha Projs').closest('a')
+    ).toHaveAttribute('href', '/repo/alpha-projs')
   })
 
   it('redirects the old /development URLs to /repo', () => {
@@ -74,6 +97,26 @@ describe('repo hub route', () => {
 })
 
 describe('repo subpages', () => {
+  it('renders Alpha Projs at /repo/alpha-projs', () => {
+    render(
+      <MemoryRouter initialEntries={['/repo/alpha-projs']}>
+        <App />
+      </MemoryRouter>
+    )
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Alpha Projs' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Still taking shape' })
+    ).toBeInTheDocument()
+    expect(screen.getByText('In progress')).toBeInTheDocument()
+    expect(screen.getByText('Coming soon')).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'Back to Repo' })
+    ).toHaveAttribute('href', '/repo')
+  })
+
   it('documents CI checks at /repo/ci', () => {
     render(
       <MemoryRouter initialEntries={['/repo/ci']}>


### PR DESCRIPTION
## Summary

- add a new `/guides` route with a minimal placeholder
- add Guides to the primary navigation
- replace the Repo label with a compact, accessible wrench menu
- add a grid-backed Repo hub with Alpha Projs and Google Analytics pages
- add a motion-safe animated build strip to the Alpha Projs placeholder
- cover the routes and navigation behavior with focused tests

## Verification

- `npm run test:run` (42 files, 201 tests)
- `npm run lint`
- production build
- browser checks for the wrench menu, animation, and Google Analytics page

## Screenshots

```screenshots
/
/guides
/repo
/repo/alpha-projs
/repo/google-analytics
```

Closes #173