### PR TITLE
analytics: track site-wide route views and titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-5MLNJQ7789');
+      gtag('config', 'G-5MLNJQ7789', { send_page_view: false });
     </script>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react'
 import { Navigate, Route, Routes } from 'react-router-dom'
+import RouteMetadata from './components/route-metadata/RouteMetadata'
 import ScrollToTop from './components/scroll-to-top/ScrollToTop'
 import AppsIndexRoute from './features/apps/routes/AppsIndexRoute'
 import PrivacyRoute from './features/apps/whoops-hoops/routes/PrivacyRoute'
@@ -23,6 +24,7 @@ import HomeRoute from './routes/HomeRoute'
 export default function App(): ReactElement {
   return (
     <>
+      <RouteMetadata />
       <ScrollToTop />
       <Routes>
         <Route path="/" element={<HomeRoute />} />

--- a/src/components/route-metadata/RouteMetadata.test.tsx
+++ b/src/components/route-metadata/RouteMetadata.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BrowserRouter, Link } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import RouteMetadata, { getRouteTitle } from './RouteMetadata'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  window.history.replaceState({}, '', '/')
+})
+
+describe('getRouteTitle', () => {
+  it.each([
+    ['/', "Leon's Website"],
+    ['/blog', "Blog | Leon's Website"],
+    ['/blog/hello-blog', "Hello Blog | Leon's Website"],
+    ['/blog/missing-post', "Post Not Found | Leon's Website"],
+    ['/guides', "Guides | Leon's Website"],
+    ['/apps', "Apps | Leon's Website"],
+    ['/apps/whoops-hoops/privacy', 'Privacy Policy | Whoops Hoops'],
+    ['/repo/alpha-projs', "Alpha Projects | Repo | Leon's Website"],
+    ['/repo/ci', "CI Checks | Repo | Leon's Website"],
+    [
+      '/repo/google-analytics',
+      "Google Analytics | Repo | Leon's Website",
+    ],
+    ['/workout-lab/', 'Workout Lab'],
+    ['/workout-lab/exercises', 'Exercises | Workout Lab'],
+    ['/sub-wait/', 'Sub-Wait'],
+    ['/sub-wait/map', 'Map | Sub-Wait'],
+    ['/sub-wait/station/F16', 'East Broadway | Sub-Wait'],
+    [
+      '/sub-wait/station/F16/N',
+      'East Broadway - Uptown & Queens | Sub-Wait',
+    ],
+    ['/sub-wait/station/unknown', 'Station Not Found | Sub-Wait'],
+    ['/tuzi', 'Tuzi'],
+    ['/tuzi/how-ranking-works', 'How Ranking Works | Tuzi'],
+  ])('returns a meaningful title for %s', (pathname, expected) => {
+    expect(getRouteTitle(pathname)).toBe(expected)
+  })
+})
+
+describe('RouteMetadata', () => {
+  it('sets titles, tracks initial and client-side pageviews, and restores the title', async () => {
+    const gtag = vi.fn()
+    vi.stubGlobal('gtag', gtag)
+    document.title = 'Original title'
+    window.history.replaceState({}, '', '/blog')
+
+    const view = render(
+      <BrowserRouter>
+        <RouteMetadata />
+        <Link to="/sub-wait/station/F16/N">Open station</Link>
+      </BrowserRouter>,
+    )
+
+    await waitFor(() => {
+      expect(document.title).toBe("Blog | Leon's Website")
+      expect(gtag).toHaveBeenCalledWith('event', 'page_view', {
+        page_location: 'http://localhost:3000/blog',
+        page_path: '/blog',
+        page_title: "Blog | Leon's Website",
+      })
+    })
+
+    await userEvent.click(screen.getByRole('link', { name: 'Open station' }))
+
+    await waitFor(() => {
+      expect(document.title).toBe(
+        'East Broadway - Uptown & Queens | Sub-Wait',
+      )
+      expect(gtag).toHaveBeenLastCalledWith('event', 'page_view', {
+        page_location: 'http://localhost:3000/sub-wait/station/F16/N',
+        page_path: '/sub-wait/station/F16/N',
+        page_title: 'East Broadway - Uptown & Queens | Sub-Wait',
+      })
+    })
+    expect(gtag).toHaveBeenCalledTimes(2)
+
+    view.unmount()
+    expect(document.title).toBe('Original title')
+  })
+
+  it('does not fail when gtag is unavailable', async () => {
+    document.title = 'Original title'
+    window.history.replaceState({}, '', '/tuzi')
+
+    render(
+      <BrowserRouter>
+        <RouteMetadata />
+      </BrowserRouter>,
+    )
+
+    await waitFor(() => expect(document.title).toBe('Tuzi'))
+  })
+})

--- a/src/components/route-metadata/RouteMetadata.tsx
+++ b/src/components/route-metadata/RouteMetadata.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useRef, type ReactElement } from 'react'
+import { useLocation } from 'react-router-dom'
+import { getBlogPostBySlug } from '../../features/blog/content'
+import { directionLabel, getStation } from '../../features/sub-wait/data/stations'
+import type { Direction } from '../../features/sub-wait/types'
+
+const SITE_TITLE = "Leon's Website"
+
+const STATIC_TITLES: Record<string, string> = {
+  '/': SITE_TITLE,
+  '/apps': `Apps | ${SITE_TITLE}`,
+  '/apps/whoops-hoops/privacy': 'Privacy Policy | Whoops Hoops',
+  '/apps/whoops-hoops/support': 'Support | Whoops Hoops',
+  '/blog': `Blog | ${SITE_TITLE}`,
+  '/development': `Repo | ${SITE_TITLE}`,
+  '/development/previews': `Pull Request Previews | Repo | ${SITE_TITLE}`,
+  '/game-nights': "Georgie's Game Nights",
+  '/georgies-board-game-nights': "Georgie's Game Nights",
+  '/guides': `Guides | ${SITE_TITLE}`,
+  '/repo': `Repo | ${SITE_TITLE}`,
+  '/repo/alpha-projs': `Alpha Projects | Repo | ${SITE_TITLE}`,
+  '/repo/ci': `CI Checks | Repo | ${SITE_TITLE}`,
+  '/repo/google-analytics': `Google Analytics | Repo | ${SITE_TITLE}`,
+  '/repo/planning': `Project Planning | Repo | ${SITE_TITLE}`,
+  '/repo/previews': `Pull Request Previews | Repo | ${SITE_TITLE}`,
+  '/repo/production': `Production Deploys | Repo | ${SITE_TITLE}`,
+  '/sub-wait': 'Sub-Wait',
+  '/sub-wait/': 'Sub-Wait',
+  '/sub-wait/architecture': 'Architecture | Sub-Wait',
+  '/sub-wait/install': 'Install | Sub-Wait',
+  '/sub-wait/map': 'Map | Sub-Wait',
+  '/sub-wait/stations': 'Stations | Sub-Wait',
+  '/tuzi': 'Tuzi',
+  '/tuzi/': 'Tuzi',
+  '/tuzi/how-ranking-works': 'How Ranking Works | Tuzi',
+  '/workout-lab': 'Workout Lab',
+  '/workout-lab/': 'Workout Lab',
+  '/workout-lab/exercises': 'Exercises | Workout Lab',
+  '/workout-lab/guide': 'Guide | Workout Lab',
+}
+
+const REDIRECT_PATHS = new Set([
+  '/development',
+  '/development/previews',
+  '/game-nights',
+])
+
+function decodePathSegment(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+export function getRouteTitle(pathname: string): string {
+  const staticTitle = STATIC_TITLES[pathname]
+  if (staticTitle) return staticTitle
+
+  const blogMatch = pathname.match(/^\/blog\/([^/]+)\/?$/)
+  if (blogMatch) {
+    const post = getBlogPostBySlug(decodePathSegment(blogMatch[1]))
+    return post
+      ? `${post.title} | ${SITE_TITLE}`
+      : `Post Not Found | ${SITE_TITLE}`
+  }
+
+  const stationMatch = pathname.match(
+    /^\/sub-wait\/station\/([^/]+)(?:\/([^/]+))?\/?$/,
+  )
+  if (stationMatch) {
+    const station = getStation(decodePathSegment(stationMatch[1]))
+    const direction = stationMatch[2]
+    if (!station || (direction && direction !== 'N' && direction !== 'S')) {
+      return 'Station Not Found | Sub-Wait'
+    }
+    if (!direction) return `${station.name} | Sub-Wait`
+
+    const typedDirection = direction as Direction
+    const label =
+      directionLabel(station, typedDirection) ??
+      (typedDirection === 'N' ? 'Northbound' : 'Southbound')
+    return `${station.name} - ${label} | Sub-Wait`
+  }
+
+  if (pathname.startsWith('/sub-wait/')) return 'Page Not Found | Sub-Wait'
+  if (pathname.startsWith('/tuzi/')) return 'Page Not Found | Tuzi'
+  if (pathname.startsWith('/workout-lab/')) return 'Page Not Found | Workout Lab'
+  return `Page Not Found | ${SITE_TITLE}`
+}
+
+type GtagWindow = Window & {
+  gtag?: (
+    _command: 'event',
+    _eventName: 'page_view',
+    _parameters: {
+      page_location: string
+      page_path: string
+      page_title: string
+    },
+  ) => void
+}
+
+export default function RouteMetadata(): ReactElement | null {
+  const location = useLocation()
+  const initialTitle = useRef(document.title)
+  const title = getRouteTitle(location.pathname)
+
+  useEffect(() => {
+    return () => {
+      document.title = initialTitle.current
+    }
+  }, [])
+
+  useEffect(() => {
+    document.title = title
+
+    if (REDIRECT_PATHS.has(location.pathname)) return
+
+    const gtag = (window as GtagWindow).gtag
+    if (!gtag) return
+
+    gtag('event', 'page_view', {
+      page_location: window.location.href,
+      page_path: `${window.location.pathname}${window.location.search}`,
+      page_title: title,
+    })
+  }, [location.pathname, location.search, title])
+
+  return null
+}

--- a/src/features/blog/routes/BlogPostRoute.tsx
+++ b/src/features/blog/routes/BlogPostRoute.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import type { CSSProperties, ReactElement } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import TopNav from '../../../components/top-nav/TopNav'
@@ -12,15 +12,6 @@ export default function BlogPostRoute(): ReactElement {
   const { slug = '' } = useParams()
   const post = getBlogPostBySlug(slug)
   const [fontScale, setFontScale] = useState(1)
-
-  useEffect(() => {
-    if (post) {
-      document.title = `${post.title} | Leon's Website`
-    }
-    return () => {
-      document.title = "Leon's Website"
-    }
-  }, [post])
 
   if (!post) {
     return (

--- a/src/features/game-nights/routes/GameNightsRoute.tsx
+++ b/src/features/game-nights/routes/GameNightsRoute.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactElement } from 'react'
+import type { ReactElement } from 'react'
 import styles from '../game-nights.module.css'
 
 const sampleGames = [
@@ -31,15 +31,6 @@ const photos = [
 ]
 
 export default function GameNightsRoute(): ReactElement {
-  useEffect(() => {
-    const previousTitle = document.title
-    document.title = "Georgie's Game Nights"
-
-    return () => {
-      document.title = previousTitle
-    }
-  }, [])
-
   return (
     <div className={styles.page}>
       <header className={styles.header}>

--- a/src/features/repo/routes/GoogleAnalyticsRoute.tsx
+++ b/src/features/repo/routes/GoogleAnalyticsRoute.tsx
@@ -57,10 +57,11 @@ export default function GoogleAnalyticsRoute(): ReactElement {
         <section className={styles.section} aria-labelledby="analytics-routing-heading">
           <h2 id="analytics-routing-heading">Client-side navigation</h2>
           <p>
-            React Router changes pages without a full document reload. GA4
-            Enhanced Measurement should have browser-history page views enabled.
-            If route changes do not appear in Realtime, add explicit{' '}
-            <code>page_view</code> events before relying on route-level reports.
+            The site sends an explicit <code>page_view</code> after each React
+            Router navigation with the current URL, path, and route-specific
+            title. Automatic tag pageviews and Enhanced Measurement
+            browser-history pageviews are disabled so each initial load and
+            client-side navigation is counted once.
           </p>
         </section>
       </main>

--- a/src/features/repo/routes/repo-routes.test.tsx
+++ b/src/features/repo/routes/repo-routes.test.tsx
@@ -117,6 +117,7 @@ describe('repo subpages', () => {
     expect(
       screen.getByRole('link', { name: 'Open Google Analytics' })
     ).toHaveAttribute('href', 'https://analytics.google.com/analytics/web/')
+    expect(screen.getByText(/site sends an explicit/)).toBeInTheDocument()
     expect(
       screen.getByRole('link', { name: 'Back to Repo' })
     ).toHaveAttribute('href', '/repo')

--- a/src/features/sub-wait/routes/ArchitectureRoute.tsx
+++ b/src/features/sub-wait/routes/ArchitectureRoute.tsx
@@ -222,13 +222,13 @@ export default function ArchitectureRoute(): ReactElement {
           </li>
         </ol>
         <p>
-          <strong>Note to future Leon:</strong> verify that GA4 Enhanced
-          Measurement has browser-history page views enabled. React Router
-          changes routes without a full document reload; if those navigation
-          events do not appear, add explicit <code>page_view</code> events on
-          route changes before relying on the reports. PR previews also load
-          the global tag, so filter or disable <code>/previews/</code> traffic
-          before treating the data as production-only.
+          The site sends an explicit <code>page_view</code> after each React
+          Router navigation, including the current page URL, path, and
+          route-specific title. Automatic pageviews are disabled in the global
+          GA4 configuration, and browser-history pageviews are disabled in the
+          web stream&apos;s Enhanced Measurement settings, to avoid duplicate
+          events. PR previews also load the global tag, so filter or disable{' '}
+          <code>/previews/</code> traffic before treating the data as production-only.
         </p>
       </DocsSection>
     </main>

--- a/src/features/sub-wait/routes/architecture-route.test.tsx
+++ b/src/features/sub-wait/routes/architecture-route.test.tsx
@@ -54,7 +54,7 @@ describe('ArchitectureRoute', () => {
     expect(
       screen.getByRole('link', { name: 'Open Google Analytics' }),
     ).toHaveAttribute('href', 'https://analytics.google.com/analytics/web/')
-    expect(screen.getByText(/Note to future Leon/)).toBeInTheDocument()
+    expect(screen.getByText(/site sends an explicit/)).toBeInTheDocument()
   })
 
   it('is reachable from the masthead and footer', () => {


### PR DESCRIPTION
Closes #176

## Summary

- centralize meaningful document titles for every routed page, including blog posts, newer Guides/Repo/Tuzi routes, and not-found states
- include Sub-Wait station names and direction labels in dynamic titles
- send guarded GA4 `page_view` events on initial loads and React Router navigation with URL, path, and title
- disable automatic tag pageviews to avoid duplicate initial events
- document the explicit tracking setup in the site-wide and Sub-Wait analytics guides

## GA4 configuration

The production web stream now has **Page changes based on browser history events** disabled in Enhanced Measurement. This matches the manual route tracking in this PR and prevents duplicate SPA pageviews after deployment. Because the stream setting is already applied, this PR should be merged promptly.

Historical events remain immutable. #178 documents the reconstructed January 1-August 12, 2026 path-level baseline.

## Validation

- `npm run test:run` (43 files, 222 tests)
- `npm run lint`
- `npm run build`
- `git diff --check`

The build retains the existing Vite large-chunk warning.