### PR TITLE
analytics: send content_group so GA4 can chart traffic per app

### DIFF
--- a/src/components/route-metadata/RouteMetadata.test.tsx
+++ b/src/components/route-metadata/RouteMetadata.test.tsx
@@ -2,7 +2,10 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BrowserRouter, Link } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import RouteMetadata, { getRouteTitle } from './RouteMetadata'
+import RouteMetadata, {
+  getRouteContentGroup,
+  getRouteTitle,
+} from './RouteMetadata'
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -45,6 +48,34 @@ describe('getRouteTitle', () => {
   })
 })
 
+describe('getRouteContentGroup', () => {
+  it.each([
+    ['/', 'home'],
+    ['/blog', 'blog'],
+    ['/blog/hello-blog', 'blog'],
+    ['/guides', 'guides'],
+    ['/apps', 'apps-index'],
+    ['/apps/whoops-hoops/privacy', 'whoops-hoops'],
+    ['/apps/whoops-hoops/support', 'whoops-hoops'],
+    ['/repo', 'repo'],
+    ['/repo/google-analytics', 'repo'],
+    ['/development/previews', 'repo'],
+    ['/sub-wait/', 'sub-wait'],
+    ['/sub-wait/station/F16/N', 'sub-wait'],
+    ['/workout-lab/exercises', 'workout-lab'],
+    ['/tuzi/how-ranking-works', 'tuzi'],
+    ['/georgies-board-game-nights', 'game-nights'],
+    ['/game-nights', 'game-nights'],
+    ['/unknown-path', 'other'],
+  ])('groups %s as %s', (pathname, expected) => {
+    expect(getRouteContentGroup(pathname)).toBe(expected)
+  })
+
+  it('does not group an unrelated path that merely shares a prefix', () => {
+    expect(getRouteContentGroup('/sub-waiting')).toBe('other')
+  })
+})
+
 describe('RouteMetadata', () => {
   it('sets titles, tracks initial and client-side pageviews, and restores the title', async () => {
     const gtag = vi.fn()
@@ -62,6 +93,7 @@ describe('RouteMetadata', () => {
     await waitFor(() => {
       expect(document.title).toBe("Blog | Leon's Website")
       expect(gtag).toHaveBeenCalledWith('event', 'page_view', {
+        content_group: 'blog',
         page_location: 'http://localhost:3000/blog',
         page_path: '/blog',
         page_title: "Blog | Leon's Website",
@@ -75,6 +107,7 @@ describe('RouteMetadata', () => {
         'East Broadway - Uptown & Queens | Sub-Wait',
       )
       expect(gtag).toHaveBeenLastCalledWith('event', 'page_view', {
+        content_group: 'sub-wait',
         page_location: 'http://localhost:3000/sub-wait/station/F16/N',
         page_path: '/sub-wait/station/F16/N',
         page_title: 'East Broadway - Uptown & Queens | Sub-Wait',

--- a/src/components/route-metadata/RouteMetadata.tsx
+++ b/src/components/route-metadata/RouteMetadata.tsx
@@ -46,6 +46,35 @@ const REDIRECT_PATHS = new Set([
   '/game-nights',
 ])
 
+/**
+ * Ordered path prefixes mapped to GA4 `content_group` values. Order matters:
+ * nested products such as `/apps/whoops-hoops` must resolve before the broader
+ * `/apps` catalog prefix.
+ */
+const CONTENT_GROUP_PREFIXES: [string, string][] = [
+  ['/apps/whoops-hoops', 'whoops-hoops'],
+  ['/apps', 'apps-index'],
+  ['/blog', 'blog'],
+  ['/guides', 'guides'],
+  ['/georgies-board-game-nights', 'game-nights'],
+  ['/game-nights', 'game-nights'],
+  ['/repo', 'repo'],
+  ['/development', 'repo'],
+  ['/sub-wait', 'sub-wait'],
+  ['/tuzi', 'tuzi'],
+  ['/workout-lab', 'workout-lab'],
+]
+
+export function getRouteContentGroup(pathname: string): string {
+  if (pathname === '/' || pathname === '') return 'home'
+
+  for (const [prefix, group] of CONTENT_GROUP_PREFIXES) {
+    if (pathname === prefix || pathname.startsWith(`${prefix}/`)) return group
+  }
+
+  return 'other'
+}
+
 function decodePathSegment(value: string): string {
   try {
     return decodeURIComponent(value)
@@ -95,6 +124,7 @@ type GtagWindow = Window & {
     _command: 'event',
     _eventName: 'page_view',
     _parameters: {
+      content_group: string
       page_location: string
       page_path: string
       page_title: string
@@ -122,6 +152,7 @@ export default function RouteMetadata(): ReactElement | null {
     if (!gtag) return
 
     gtag('event', 'page_view', {
+      content_group: getRouteContentGroup(location.pathname),
       page_location: window.location.href,
       page_path: `${window.location.pathname}${window.location.search}`,
       page_title: title,

--- a/src/features/repo/routes/GoogleAnalyticsRoute.tsx
+++ b/src/features/repo/routes/GoogleAnalyticsRoute.tsx
@@ -64,6 +64,26 @@ export default function GoogleAnalyticsRoute(): ReactElement {
             client-side navigation is counted once.
           </p>
         </section>
+
+        <section className={styles.section} aria-labelledby="analytics-groups-heading">
+          <h2 id="analytics-groups-heading">Traffic by app</h2>
+          <p>
+            Each pageview also sends GA4&apos;s built-in{' '}
+            <code>content_group</code> parameter, derived from the route prefix,
+            so every app reports as one value instead of many separate paths.
+            Groups include <code>home</code>, <code>blog</code>,{' '}
+            <code>guides</code>, <code>apps-index</code>,{' '}
+            <code>whoops-hoops</code>, <code>repo</code>, <code>sub-wait</code>,{' '}
+            <code>workout-lab</code>, <code>tuzi</code>, and{' '}
+            <code>game-nights</code>.
+          </p>
+          <p>
+            Build a custom report with <strong>Content group</strong> as the
+            primary dimension to chart views per app over time. Content groups
+            are not retroactive, so they only describe traffic collected after
+            this shipped.
+          </p>
+        </section>
       </main>
     </div>
   )


### PR DESCRIPTION
Refs #183

## Summary

- add `getRouteContentGroup` with ordered path-prefix matching so nested routes resolve before broader ones
- send GA4's built-in `content_group` parameter on every explicit `page_view`
- document the new grouping and its non-retroactive behavior on the Repo analytics page

## Why

GA4 charts one line per value of a report's primary dimension. With only page path or page title available, `/workout-lab`, `/workout-lab/guide`, and `/workout-lab/exercises` plot as three unrelated lines. `content_group` is a built-in dimension, so a custom report can chart one line per app with no Custom Definition registration and no activation delay.

## Groups

`home`, `blog`, `guides`, `apps-index`, `whoops-hoops`, `repo`, `sub-wait`, `workout-lab`, `tuzi`, `game-nights`, and `other`.

`/apps/whoops-hoops/*` is matched before `/apps`, and legacy `/development*` maps to `repo` alongside the current `/repo*` routes.

## Caveat

Content groups are not retroactive; they describe traffic collected after deployment only. Historical app-level reporting still requires path-based grouping.

## Validation

- `npm run test:run` (44 files, 242 tests)
- `npm run lint`
- `npm run build`
- `git diff --check`

The build retains the existing Vite large-chunk warning.