### PR TITLE
GA dashboard: full-page redesign, more graphs, date picker, quality analyses

### DIFF
--- a/alpha-projs/ga-traffic-dashboard/package-lock.json
+++ b/alpha-projs/ga-traffic-dashboard/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@google-analytics/data": "^4.12.0",
         "react": "^19.0.0",
+        "react-day-picker": "^10.0.1",
         "react-dom": "^19.0.0",
         "recharts": "^2.15.0"
       },
@@ -312,6 +313,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
+      "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
@@ -1498,7 +1505,7 @@
       "version": "19.2.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1960,6 +1967,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -2852,6 +2869,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-day-picker": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-10.0.1.tgz",
+      "integrity": "sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.4.1",
+        "date-fns": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-dom": {

--- a/alpha-projs/ga-traffic-dashboard/package.json
+++ b/alpha-projs/ga-traffic-dashboard/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@google-analytics/data": "^4.12.0",
     "react": "^19.0.0",
+    "react-day-picker": "^10.0.1",
     "react-dom": "^19.0.0",
     "recharts": "^2.15.0"
   },

--- a/alpha-projs/ga-traffic-dashboard/server/index.mjs
+++ b/alpha-projs/ga-traffic-dashboard/server/index.mjs
@@ -27,70 +27,194 @@ if (!PROPERTY_ID) {
   process.exit(1)
 }
 
-// Credentials: set GOOGLE_APPLICATION_CREDENTIALS to the path of a service
-// account key JSON that has Viewer access on the GA4 property.
 const client = new BetaAnalyticsDataClient()
 
-async function runTrafficReport({ start, end, granularity, metric }) {
-  const dateDimension = granularity === 'week' ? 'yearWeek' : 'date'
-  const [response] = await client.runReport({
-    property: `properties/${PROPERTY_ID}`,
-    dateRanges: [{ startDate: start, endDate: end }],
-    dimensions: [{ name: dateDimension }, { name: 'pagePath' }],
-    metrics: [{ name: metric }],
-    limit: 250000,
-  })
-  return (response.rows ?? []).map((row) => ({
-    date: row.dimensionValues[0].value,
-    pagePath: row.dimensionValues[1].value,
-    value: Number(row.metricValues[0].value),
-  }))
+// ---------------------------------------------------------------------------
+// Shared helpers
+
+const DATE_RE = /^(\d{4}-\d{2}-\d{2}|\d+daysAgo|today|yesterday)$/
+
+function parseRange(url) {
+  const start = url.searchParams.get('start') ?? '90daysAgo'
+  const end = url.searchParams.get('end') ?? 'today'
+  if (!DATE_RE.test(start) || !DATE_RE.test(end)) {
+    throw Object.assign(
+      new Error('start/end must be YYYY-MM-DD, NdaysAgo, today, or yesterday'),
+      { statusCode: 400 },
+    )
+  }
+  const granularity =
+    url.searchParams.get('granularity') === 'week' ? 'week' : 'day'
+  return { start, end, granularity }
 }
 
-const ALLOWED_METRICS = new Set([
-  'screenPageViews',
-  'activeUsers',
-  'sessions',
-])
+const cache = new Map()
+const CACHE_TTL_MS = 5 * 60 * 1000
+
+async function cached(key, fn) {
+  const hit = cache.get(key)
+  if (hit && Date.now() - hit.at < CACHE_TTL_MS) return hit.value
+  const value = await fn()
+  cache.set(key, { at: Date.now(), value })
+  return value
+}
+
+async function runReport(request) {
+  const [response] = await client.runReport({
+    property: `properties/${PROPERTY_ID}`,
+    limit: 250000,
+    ...request,
+  })
+  return response
+}
+
+const dim = (name) => ({ name })
+const met = (name) => ({ name })
+const num = (value) => Number(value ?? 0)
+
+// ---------------------------------------------------------------------------
+// Endpoint implementations
+
+// Charts 1-5: per-date, per-path rows carrying all three volume metrics.
+async function getTraffic({ start, end, granularity }) {
+  const dateDimension = granularity === 'week' ? 'yearWeek' : 'date'
+  const response = await runReport({
+    dateRanges: [{ startDate: start, endDate: end }],
+    dimensions: [dim(dateDimension), dim('pagePath')],
+    metrics: [met('screenPageViews'), met('activeUsers'), met('sessions')],
+  })
+  return {
+    granularity,
+    rows: (response.rows ?? []).map((row) => ({
+      date: row.dimensionValues[0].value,
+      pagePath: row.dimensionValues[1].value,
+      screenPageViews: num(row.metricValues[0].value),
+      activeUsers: num(row.metricValues[1].value),
+      sessions: num(row.metricValues[2].value),
+    })),
+  }
+}
+
+// KPI cards: totals for the requested range and the previous equal-length
+// period, in one request (GA4 supports two dateRanges per call).
+async function getSummary({ start, end }) {
+  const response = await runReport({
+    dateRanges: [
+      { startDate: start, endDate: end, name: 'current' },
+      // GA4 has no relative "previous period" syntax, so the client sends
+      // explicit YYYY-MM-DD for both ranges when it wants deltas.
+    ],
+    dimensions: [],
+    metrics: [met('screenPageViews'), met('activeUsers'), met('sessions')],
+  })
+  const row = response.rows?.[0]
+  return {
+    screenPageViews: num(row?.metricValues[0]?.value),
+    activeUsers: num(row?.metricValues[1]?.value),
+    sessions: num(row?.metricValues[2]?.value),
+  }
+}
+
+// Table 6 + chart 8: per-page volume and engagement time.
+async function getPages({ start, end }) {
+  const response = await runReport({
+    dateRanges: [{ startDate: start, endDate: end }],
+    dimensions: [dim('pagePath')],
+    metrics: [
+      met('screenPageViews'),
+      met('activeUsers'),
+      met('userEngagementDuration'),
+    ],
+    orderBys: [{ metric: { metricName: 'screenPageViews' }, desc: true }],
+    limit: 250,
+  })
+  return {
+    rows: (response.rows ?? []).map((row) => ({
+      pagePath: row.dimensionValues[0].value,
+      screenPageViews: num(row.metricValues[0].value),
+      activeUsers: num(row.metricValues[1].value),
+      engagementSeconds: num(row.metricValues[2].value),
+    })),
+  }
+}
+
+// Section 7: bounce/engagement rate per date+path so the client can group
+// into apps. Section 9: browser breakdown for the automation diagnostic.
+async function getQuality({ start, end, granularity }) {
+  const dateDimension = granularity === 'week' ? 'yearWeek' : 'date'
+  const [rates, browsers] = await Promise.all([
+    runReport({
+      dateRanges: [{ startDate: start, endDate: end }],
+      dimensions: [dim(dateDimension), dim('pagePath')],
+      metrics: [met('bounceRate'), met('engagementRate'), met('sessions')],
+    }),
+    runReport({
+      dateRanges: [{ startDate: start, endDate: end }],
+      dimensions: [dim('browser')],
+      metrics: [
+        met('sessions'),
+        met('activeUsers'),
+        met('userEngagementDuration'),
+        met('screenPageViews'),
+      ],
+      orderBys: [{ metric: { metricName: 'sessions' }, desc: true }],
+      limit: 50,
+    }),
+  ])
+  return {
+    granularity,
+    rates: (rates.rows ?? []).map((row) => ({
+      date: row.dimensionValues[0].value,
+      pagePath: row.dimensionValues[1].value,
+      bounceRate: Number(row.metricValues[0].value ?? 0),
+      engagementRate: Number(row.metricValues[1].value ?? 0),
+      sessions: num(row.metricValues[2].value),
+    })),
+    browsers: (browsers.rows ?? []).map((row) => ({
+      browser: row.dimensionValues[0].value,
+      sessions: num(row.metricValues[0].value),
+      activeUsers: num(row.metricValues[1].value),
+      engagementSeconds: num(row.metricValues[2].value),
+      screenPageViews: num(row.metricValues[3].value),
+    })),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// HTTP server
+
+const ROUTES = {
+  '/api/traffic': getTraffic,
+  '/api/summary': getSummary,
+  '/api/pages': getPages,
+  '/api/quality': getQuality,
+}
 
 const server = http.createServer(async (req, res) => {
   const url = new URL(req.url, `http://localhost:${PORT}`)
+  const handler = ROUTES[url.pathname]
 
-  if (url.pathname !== '/api/traffic') {
+  if (!handler) {
     res.writeHead(404, { 'content-type': 'application/json' })
     res.end(JSON.stringify({ error: 'not found' }))
     return
   }
 
-  const start = url.searchParams.get('start') ?? '90daysAgo'
-  const end = url.searchParams.get('end') ?? 'today'
-  const granularity =
-    url.searchParams.get('granularity') === 'week' ? 'week' : 'day'
-  const metric = url.searchParams.get('metric') ?? 'screenPageViews'
-
-  if (!ALLOWED_METRICS.has(metric)) {
-    res.writeHead(400, { 'content-type': 'application/json' })
-    res.end(JSON.stringify({ error: `metric must be one of ${[...ALLOWED_METRICS].join(', ')}` }))
-    return
-  }
-
   try {
-    const rows = await runTrafficReport({ start, end, granularity, metric })
+    const params = parseRange(url)
+    const key = `${url.pathname}?start=${params.start}&end=${params.end}&g=${params.granularity}`
+    const body = await cached(key, () => handler(params))
     res.writeHead(200, { 'content-type': 'application/json' })
-    res.end(JSON.stringify({ granularity, metric, rows }))
+    res.end(JSON.stringify(body))
   } catch (error) {
     console.error(error)
-    res.writeHead(500, { 'content-type': 'application/json' })
+    res.writeHead(error.statusCode ?? 500, {
+      'content-type': 'application/json',
+    })
     res.end(JSON.stringify({ error: String(error.message ?? error) }))
   }
 })
 
 server.listen(PORT, () => {
   console.log(`GA proxy listening on http://localhost:${PORT}`)
-  if (!process.env.GOOGLE_APPLICATION_CREDENTIALS) {
-    console.warn(
-      'WARNING: GOOGLE_APPLICATION_CREDENTIALS is not set. ' +
-        'API calls will fail until you point it at a service account key.',
-    )
-  }
 })

--- a/alpha-projs/ga-traffic-dashboard/src/App.tsx
+++ b/alpha-projs/ga-traffic-dashboard/src/App.tsx
@@ -1,120 +1,90 @@
 import { useEffect, useMemo, useState } from 'react'
 import {
-  CartesianGrid,
-  Legend,
-  Line,
-  LineChart,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from 'recharts'
-import { ALL_GROUPS, colorForGroup, groupForPath } from './appGroups'
+  ApiUnavailableError,
+  fetchPages,
+  fetchQuality,
+  fetchSummary,
+  fetchTraffic,
+  type PageRow,
+  type QualityResponse,
+  type SummaryResponse,
+  type TrafficResponse,
+} from './api'
+import { ALL_GROUPS } from './appGroups'
+import { groupByApp, toShare } from './charts'
+import { AppLines, AppShareArea } from './components/AppLineChart'
+import KpiCards from './components/KpiCards'
+import QualitySection from './components/QualitySection'
+import RangePicker from './components/RangePicker'
+import SparklineGrid from './components/SparklineGrid'
+import StaticNotice from './components/StaticNotice'
+import TopPagesTable from './components/TopPagesTable'
+import { PRESETS, autoGranularity, previousPeriod, type DateRange } from './dates'
+import styles from './dashboard.module.css'
 
-type ApiRow = { date: string; pagePath: string; value: number }
-type ApiResponse = {
-  granularity: 'day' | 'week'
-  metric: string
-  rows: ApiRow[]
-  error?: string
-}
-
-const RANGES = [
-  { label: '30 days', start: '30daysAgo' },
-  { label: '90 days', start: '90daysAgo' },
-  { label: '6 months', start: '180daysAgo' },
-  { label: '12 months', start: '365daysAgo' },
-]
-
-const METRICS = [
-  { label: 'Views', value: 'screenPageViews' },
-  { label: 'Active users', value: 'activeUsers' },
-  { label: 'Sessions', value: 'sessions' },
-]
-
-// Optional deep link to the GA4 report for this property. Kept out of the
-// repo: set VITE_GA_REPORT_URL in .env.local (see .env.example).
+// Optional deep link to the GA4 report for this property (set in .env.local).
 const GA_REPORT_URL = import.meta.env.VITE_GA_REPORT_URL as string | undefined
 
-function formatDateLabel(raw: string, granularity: 'day' | 'week'): string {
-  if (granularity === 'week') {
-    // yearWeek arrives as YYYYWW
-    return `${raw.slice(0, 4)}-W${raw.slice(4)}`
-  }
-  return `${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6)}`
-}
+const METRIC_SECTIONS = [
+  { metric: 'screenPageViews', title: 'Views by app' },
+  { metric: 'activeUsers', title: 'Active users by app' },
+  { metric: 'sessions', title: 'Sessions by app' },
+] as const
 
 export default function App() {
-  const [start, setStart] = useState('90daysAgo')
-  const [metric, setMetric] = useState('screenPageViews')
-  const [granularity, setGranularity] = useState<'day' | 'week'>('week')
+  const [range, setRange] = useState<DateRange>(() => PRESETS[2].range()) // 90 days
   const [hidden, setHidden] = useState<Set<string>>(new Set(['preview']))
-  const [data, setData] = useState<ApiResponse | null>(null)
-  const [error, setError] = useState<string | null>(null)
+
+  const [traffic, setTraffic] = useState<TrafficResponse | null>(null)
+  const [summary, setSummary] = useState<SummaryResponse | null>(null)
+  const [prevSummary, setPrevSummary] = useState<SummaryResponse | null>(null)
+  const [pages, setPages] = useState<PageRow[] | null>(null)
+  const [quality, setQuality] = useState<QualityResponse | null>(null)
+
   const [apiUnavailable, setApiUnavailable] = useState(false)
+  const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
+
+  const granularity = autoGranularity(range)
 
   useEffect(() => {
     const controller = new AbortController()
+    const { signal } = controller
     setLoading(true)
     setError(null)
-    setApiUnavailable(false)
-    fetch(
-      `/api/traffic?start=${start}&end=today&granularity=${granularity}&metric=${metric}`,
-      { signal: controller.signal },
-    )
-      .then(async (response) => {
-        const contentType = response.headers.get('content-type') ?? ''
-        if (!contentType.includes('application/json')) {
-          // Static hosting (e.g. GitHub Pages) has no /api route and
-          // answers with an HTML 404 page instead of JSON.
-          setApiUnavailable(true)
-          return
-        }
-        const body = (await response.json()) as ApiResponse
-        if (!response.ok) throw new Error(body.error ?? response.statusText)
-        setData(body)
-      })
-      .catch((err: unknown) => {
-        if ((err as Error).name === 'AbortError') return
-        if (err instanceof TypeError) {
-          // Network-level failure: no server listening at all.
-          setApiUnavailable(true)
-          return
-        }
-        setError(String(err))
-      })
-      .finally(() => setLoading(false))
-    return () => controller.abort()
-  }, [start, metric, granularity])
 
-  const { chartData, groupNames } = useMemo(() => {
-    if (!data) return { chartData: [], groupNames: [] as string[] }
-
-    const byDate = new Map<string, Record<string, number | string>>()
-    const totals = new Map<string, number>()
-
-    for (const row of data.rows) {
-      const group = groupForPath(row.pagePath)
-      totals.set(group, (totals.get(group) ?? 0) + row.value)
-      let bucket = byDate.get(row.date)
-      if (!bucket) {
-        bucket = { date: formatDateLabel(row.date, data.granularity) }
-        byDate.set(row.date, bucket)
-      }
-      bucket[group] = ((bucket[group] as number) ?? 0) + row.value
+    const handle = (err: unknown) => {
+      if ((err as Error).name === 'AbortError') return
+      if (err instanceof ApiUnavailableError) setApiUnavailable(true)
+      else setError(String(err))
     }
 
-    const names = [...totals.entries()]
-      .sort((a, b) => b[1] - a[1])
-      .map(([name]) => name)
+    Promise.all([
+      fetchTraffic(range, granularity, signal).then(setTraffic),
+      fetchSummary(range, signal).then(setSummary),
+      fetchSummary(previousPeriod(range), signal).then(setPrevSummary),
+      fetchPages(range, signal).then((body) => setPages(body.rows)),
+      fetchQuality(range, granularity, signal).then(setQuality),
+    ])
+      .catch(handle)
+      .finally(() => setLoading(false))
 
-    const rows = [...byDate.entries()]
-      .sort((a, b) => a[0].localeCompare(b[0]))
-      .map(([, bucket]) => bucket)
+    return () => controller.abort()
+  }, [range, granularity])
 
-    return { chartData: rows, groupNames: names }
-  }, [data])
+  const volumeSeries = useMemo(() => {
+    if (!traffic) return null
+    return {
+      screenPageViews: groupByApp(traffic.rows, 'screenPageViews', traffic.granularity),
+      activeUsers: groupByApp(traffic.rows, 'activeUsers', traffic.granularity),
+      sessions: groupByApp(traffic.rows, 'sessions', traffic.granularity),
+    }
+  }, [traffic])
+
+  const shareData = useMemo(
+    () => (volumeSeries ? toShare(volumeSeries.screenPageViews) : null),
+    [volumeSeries],
+  )
 
   const toggle = (name: string) => {
     setHidden((prev) => {
@@ -127,159 +97,118 @@ export default function App() {
 
   if (apiUnavailable) {
     return (
-      <main style={{ fontFamily: 'system-ui', margin: '3rem auto', maxWidth: 640, padding: '0 1rem' }}>
-        <h1 style={{ fontSize: '1.4rem' }}>Traffic by app - leoncheng57.github.io</h1>
-        <div
-          style={{
-            border: '1px solid #d1d5db',
-            borderRadius: 12,
-            padding: '1.5rem',
-            marginTop: '1rem',
-            background: '#f9fafb',
-          }}
-        >
-          <h2 style={{ fontSize: '1.05rem', marginBottom: '0.5rem' }}>
-            This is a static deployment - no data here
-          </h2>
-          <p style={{ lineHeight: 1.6, marginBottom: '1rem' }}>
-            The chart needs a local API server that queries Google Analytics
-            with private credentials, so it only works on your machine. Static
-            hosts like GitHub Pages can&apos;t run it.
-          </p>
-          <p style={{ marginBottom: '0.5rem' }}>Run it locally:</p>
-          <pre
-            style={{
-              background: '#111827',
-              color: '#e5e7eb',
-              borderRadius: 8,
-              padding: '0.9rem 1rem',
-              fontSize: '0.85rem',
-              overflowX: 'auto',
-              marginBottom: '1rem',
-            }}
-          >
-            {`git clone git@github.com:leoncheng57/leoncheng57.github.io.git
-cd leoncheng57.github.io/alpha-projs/ga-traffic-dashboard
-npm install
-cp .env.example .env.local   # fill in your GA4 property + key path
-npm run dev
-# open http://localhost:5199`}
-          </pre>
-          <p style={{ lineHeight: 1.6 }}>
-            {GA_REPORT_URL ? (
-              <>
-                Or view the full data directly in{' '}
-                <a href={GA_REPORT_URL} target="_blank" rel="noreferrer">
-                  Google Analytics - Pages and screens
-                </a>
-                .
-              </>
-            ) : (
-              'Or view the full data directly in Google Analytics.'
-            )}
-          </p>
+      <main className={styles.page}>
+        <div className={styles.content}>
+          <p className={styles.eyebrow}>Alpha projs / GA traffic dashboard</p>
+          <h1>Traffic by app</h1>
+          <StaticNotice />
         </div>
       </main>
     )
   }
 
   return (
-    <main style={{ fontFamily: 'system-ui', margin: '2rem auto', maxWidth: 1100, padding: '0 1rem' }}>
-      <div
-        style={{
-          display: 'flex',
-          flexWrap: 'wrap',
-          alignItems: 'baseline',
-          justifyContent: 'space-between',
-          gap: '0.5rem',
-        }}
-      >
-        <h1 style={{ fontSize: '1.4rem' }}>Traffic by app - leoncheng57.github.io</h1>
-        {GA_REPORT_URL && (
-          <a href={GA_REPORT_URL} target="_blank" rel="noreferrer" style={{ fontSize: '0.9rem' }}>
-            Open in Google Analytics
-          </a>
+    <main className={styles.page}>
+      <div className={styles.content}>
+        <header className={styles.pageHeader}>
+          <div>
+            <p className={styles.eyebrow}>Alpha projs / GA traffic dashboard</p>
+            <h1>Traffic by app</h1>
+          </div>
+          {GA_REPORT_URL && (
+            <a
+              className={styles.headerLinks}
+              href={GA_REPORT_URL}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Open in Google Analytics
+            </a>
+          )}
+        </header>
+
+        <RangePicker range={range} onChange={setRange} />
+
+        <div className={styles.pillRow}>
+          {ALL_GROUPS.map((group) => (
+            <button
+              key={group.name}
+              onClick={() => toggle(group.name)}
+              className={styles.pill}
+              style={{
+                borderColor: group.color,
+                background: hidden.has(group.name) ? 'transparent' : group.color,
+                color: hidden.has(group.name) ? group.color : '#fff',
+              }}
+            >
+              {group.name}
+            </button>
+          ))}
+          {loading && <span className={styles.loading}>loading…</span>}
+        </div>
+
+        {error && (
+          <p className={styles.error}>
+            {error} - is the API server running with valid credentials?
+          </p>
+        )}
+
+        <section className={styles.section}>
+          <KpiCards current={summary} previous={prevSummary} />
+        </section>
+
+        {volumeSeries &&
+          METRIC_SECTIONS.map(({ metric, title }) => (
+            <section key={metric} className={styles.section}>
+              <h2>{title}</h2>
+              <div className={styles.card}>
+                <AppLines
+                  data={volumeSeries[metric].chartData}
+                  groupNames={volumeSeries[metric].groupNames}
+                  hidden={hidden}
+                />
+              </div>
+            </section>
+          ))}
+
+        {volumeSeries && shareData && (
+          <section className={styles.section}>
+            <h2>Share of traffic</h2>
+            <p className={styles.sectionNote}>
+              Each app&apos;s percentage of total views over time.
+            </p>
+            <div className={styles.card}>
+              <AppShareArea
+                data={shareData}
+                groupNames={volumeSeries.screenPageViews.groupNames}
+                hidden={hidden}
+              />
+            </div>
+          </section>
+        )}
+
+        {volumeSeries && (
+          <section className={styles.section}>
+            <h2>Per-app trend</h2>
+            <p className={styles.sectionNote}>
+              Views over the selected range; arrow compares the second half to
+              the first.
+            </p>
+            <SparklineGrid series={volumeSeries.screenPageViews} />
+          </section>
+        )}
+
+        {pages && (
+          <section className={styles.section}>
+            <h2>Top pages</h2>
+            <TopPagesTable rows={pages} />
+          </section>
+        )}
+
+        {quality && pages && (
+          <QualitySection quality={quality} pages={pages} hidden={hidden} />
         )}
       </div>
-
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1.5rem', margin: '1rem 0' }}>
-        <label>
-          Range{' '}
-          <select value={start} onChange={(e) => setStart(e.target.value)}>
-            {RANGES.map((r) => (
-              <option key={r.start} value={r.start}>{r.label}</option>
-            ))}
-          </select>
-        </label>
-        <label>
-          Metric{' '}
-          <select value={metric} onChange={(e) => setMetric(e.target.value)}>
-            {METRICS.map((m) => (
-              <option key={m.value} value={m.value}>{m.label}</option>
-            ))}
-          </select>
-        </label>
-        <label>
-          Granularity{' '}
-          <select
-            value={granularity}
-            onChange={(e) => setGranularity(e.target.value as 'day' | 'week')}
-          >
-            <option value="day">Daily</option>
-            <option value="week">Weekly</option>
-          </select>
-        </label>
-      </div>
-
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginBottom: '1rem' }}>
-        {ALL_GROUPS.map((group) => (
-          <button
-            key={group.name}
-            onClick={() => toggle(group.name)}
-            style={{
-              border: `2px solid ${group.color}`,
-              borderRadius: 999,
-              padding: '0.2rem 0.7rem',
-              background: hidden.has(group.name) ? 'transparent' : group.color,
-              color: hidden.has(group.name) ? group.color : '#fff',
-              cursor: 'pointer',
-            }}
-          >
-            {group.name}
-          </button>
-        ))}
-      </div>
-
-      {error && (
-        <p style={{ color: '#b91c1c' }}>
-          {error} - is the API server running with valid credentials?
-        </p>
-      )}
-      {loading && <p>Loading...</p>}
-
-      <ResponsiveContainer width="100%" height={480}>
-        <LineChart data={chartData} margin={{ top: 8, right: 16, bottom: 8, left: 0 }}>
-          <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="date" tick={{ fontSize: 12 }} />
-          <YAxis tick={{ fontSize: 12 }} allowDecimals={false} />
-          <Tooltip />
-          <Legend />
-          {groupNames
-            .filter((name) => !hidden.has(name))
-            .map((name) => (
-              <Line
-                key={name}
-                type="monotone"
-                dataKey={name}
-                stroke={colorForGroup(name)}
-                strokeWidth={2}
-                dot={{ r: 2.5, strokeWidth: 0, fill: colorForGroup(name) }}
-                connectNulls
-                isAnimationActive={false}
-              />
-            ))}
-        </LineChart>
-      </ResponsiveContainer>
     </main>
   )
 }

--- a/alpha-projs/ga-traffic-dashboard/src/api.ts
+++ b/alpha-projs/ga-traffic-dashboard/src/api.ts
@@ -1,0 +1,105 @@
+import type { DateRange } from './dates'
+
+export type TrafficRow = {
+  date: string
+  pagePath: string
+  screenPageViews: number
+  activeUsers: number
+  sessions: number
+}
+
+export type TrafficResponse = {
+  granularity: 'day' | 'week'
+  rows: TrafficRow[]
+}
+
+export type SummaryResponse = {
+  screenPageViews: number
+  activeUsers: number
+  sessions: number
+}
+
+export type PageRow = {
+  pagePath: string
+  screenPageViews: number
+  activeUsers: number
+  engagementSeconds: number
+}
+
+export type QualityRateRow = {
+  date: string
+  pagePath: string
+  bounceRate: number
+  engagementRate: number
+  sessions: number
+}
+
+export type BrowserRow = {
+  browser: string
+  sessions: number
+  activeUsers: number
+  engagementSeconds: number
+  screenPageViews: number
+}
+
+export type QualityResponse = {
+  granularity: 'day' | 'week'
+  rates: QualityRateRow[]
+  browsers: BrowserRow[]
+}
+
+export class ApiUnavailableError extends Error {}
+
+async function getJson<T>(
+  path: string,
+  params: Record<string, string>,
+  signal: AbortSignal,
+): Promise<T> {
+  const query = new URLSearchParams(params).toString()
+  let response: Response
+  try {
+    response = await fetch(`${path}?${query}`, { signal })
+  } catch (error) {
+    if ((error as Error).name === 'AbortError') throw error
+    // Network-level failure: no server listening at all.
+    throw new ApiUnavailableError()
+  }
+  const contentType = response.headers.get('content-type') ?? ''
+  if (!contentType.includes('application/json')) {
+    // Static hosting (e.g. GitHub Pages) answers with an HTML 404 page.
+    throw new ApiUnavailableError()
+  }
+  const body = (await response.json()) as T & { error?: string }
+  if (!response.ok) throw new Error(body.error ?? response.statusText)
+  return body
+}
+
+export function fetchTraffic(
+  range: DateRange,
+  granularity: 'day' | 'week',
+  signal: AbortSignal,
+): Promise<TrafficResponse> {
+  return getJson('/api/traffic', { ...range, granularity }, signal)
+}
+
+export function fetchSummary(
+  range: DateRange,
+  signal: AbortSignal,
+): Promise<SummaryResponse> {
+  return getJson('/api/summary', { ...range }, signal)
+}
+
+export function fetchPages(
+  range: DateRange,
+  signal: AbortSignal,
+): Promise<{ rows: PageRow[] }> {
+  return getJson('/api/pages', { ...range }, signal)
+}
+
+export function fetchQuality(
+  range: DateRange,
+  granularity: 'day' | 'week',
+  signal: AbortSignal,
+): Promise<QualityResponse> {
+  return getJson('/api/quality', { ...range, granularity }, signal)
+}

--- a/alpha-projs/ga-traffic-dashboard/src/charts.ts
+++ b/alpha-projs/ga-traffic-dashboard/src/charts.ts
@@ -1,0 +1,68 @@
+import type { TrafficRow } from './api'
+import { groupForPath } from './appGroups'
+import { formatDateLabel } from './dates'
+
+export type ChartRow = Record<string, number | string>
+
+export type GroupedSeries = {
+  chartData: ChartRow[]
+  groupNames: string[]
+  totals: Map<string, number>
+}
+
+/**
+ * Pivot per-path rows into one chart row per date with a numeric column per
+ * app group, for a single metric.
+ */
+export function groupByApp(
+  rows: TrafficRow[],
+  metric: 'screenPageViews' | 'activeUsers' | 'sessions',
+  granularity: 'day' | 'week',
+): GroupedSeries {
+  const byDate = new Map<string, ChartRow>()
+  const totals = new Map<string, number>()
+
+  for (const row of rows) {
+    const group = groupForPath(row.pagePath)
+    const value = row[metric]
+    totals.set(group, (totals.get(group) ?? 0) + value)
+    let bucket = byDate.get(row.date)
+    if (!bucket) {
+      bucket = { date: formatDateLabel(row.date, granularity) }
+      byDate.set(row.date, bucket)
+    }
+    bucket[group] = ((bucket[group] as number) ?? 0) + value
+  }
+
+  const groupNames = [...totals.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([name]) => name)
+
+  const chartData = [...byDate.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([, bucket]) => bucket)
+
+  return { chartData, groupNames, totals }
+}
+
+/** Convert absolute values into per-date percentage shares (0-100). */
+export function toShare(series: GroupedSeries): ChartRow[] {
+  return series.chartData.map((row) => {
+    const total = series.groupNames.reduce(
+      (sum, name) => sum + ((row[name] as number) ?? 0),
+      0,
+    )
+    const out: ChartRow = { date: row.date }
+    for (const name of series.groupNames) {
+      out[name] = total > 0 ? (((row[name] as number) ?? 0) / total) * 100 : 0
+    }
+    return out
+  })
+}
+
+export function formatSeconds(total: number): string {
+  const minutes = Math.floor(total / 60)
+  const seconds = Math.round(total % 60)
+  if (minutes === 0) return `${seconds}s`
+  return `${minutes}m ${String(seconds).padStart(2, '0')}s`
+}

--- a/alpha-projs/ga-traffic-dashboard/src/components/AppLineChart.tsx
+++ b/alpha-projs/ga-traffic-dashboard/src/components/AppLineChart.tsx
@@ -1,0 +1,100 @@
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import { colorForGroup } from '../appGroups'
+import type { ChartRow } from '../charts'
+
+const AXIS = { fontSize: 11, fontFamily: 'ui-monospace, Menlo, monospace' }
+const TOOLTIP_STYLE = {
+  border: '2px solid #10233d',
+  borderRadius: 0,
+  background: '#f5f8f7',
+  fontSize: '0.78rem',
+  fontFamily: 'ui-monospace, Menlo, monospace',
+}
+
+type LineProps = {
+  data: ChartRow[]
+  groupNames: string[]
+  hidden: Set<string>
+  height?: number
+}
+
+export function AppLines({ data, groupNames, hidden, height = 340 }: LineProps) {
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <LineChart data={data} margin={{ top: 8, right: 16, bottom: 4, left: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="rgba(16,35,61,0.25)" />
+        <XAxis dataKey="date" tick={AXIS} stroke="#10233d" />
+        <YAxis tick={AXIS} stroke="#10233d" allowDecimals={false} />
+        <Tooltip contentStyle={TOOLTIP_STYLE} />
+        <Legend wrapperStyle={{ fontSize: '0.78rem' }} />
+        {groupNames
+          .filter((name) => !hidden.has(name))
+          .map((name) => (
+            <Line
+              key={name}
+              type="monotone"
+              dataKey={name}
+              stroke={colorForGroup(name)}
+              strokeWidth={2}
+              dot={{ r: 2.5, strokeWidth: 0, fill: colorForGroup(name) }}
+              connectNulls
+              isAnimationActive={false}
+            />
+          ))}
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}
+
+type AreaProps = {
+  data: ChartRow[]
+  groupNames: string[]
+  hidden: Set<string>
+}
+
+export function AppShareArea({ data, groupNames, hidden }: AreaProps) {
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <AreaChart data={data} margin={{ top: 8, right: 16, bottom: 4, left: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="rgba(16,35,61,0.25)" />
+        <XAxis dataKey="date" tick={AXIS} stroke="#10233d" />
+        <YAxis
+          tick={AXIS}
+          stroke="#10233d"
+          domain={[0, 100]}
+          tickFormatter={(value: number) => `${value}%`}
+        />
+        <Tooltip
+          contentStyle={TOOLTIP_STYLE}
+          formatter={(value: number) => `${value.toFixed(1)}%`}
+        />
+        <Legend wrapperStyle={{ fontSize: '0.78rem' }} />
+        {groupNames
+          .filter((name) => !hidden.has(name))
+          .map((name) => (
+            <Area
+              key={name}
+              type="monotone"
+              dataKey={name}
+              stackId="share"
+              stroke={colorForGroup(name)}
+              fill={colorForGroup(name)}
+              fillOpacity={0.75}
+              isAnimationActive={false}
+            />
+          ))}
+      </AreaChart>
+    </ResponsiveContainer>
+  )
+}

--- a/alpha-projs/ga-traffic-dashboard/src/components/KpiCards.tsx
+++ b/alpha-projs/ga-traffic-dashboard/src/components/KpiCards.tsx
@@ -1,0 +1,53 @@
+import type { SummaryResponse } from '../api'
+import styles from '../dashboard.module.css'
+
+type Props = {
+  current: SummaryResponse | null
+  previous: SummaryResponse | null
+}
+
+const KPIS: { key: keyof SummaryResponse; label: string }[] = [
+  { key: 'screenPageViews', label: 'Views' },
+  { key: 'activeUsers', label: 'Active users' },
+  { key: 'sessions', label: 'Sessions' },
+]
+
+function formatCount(value: number): string {
+  if (value >= 10_000) return `${(value / 1000).toFixed(1)}k`
+  return value.toLocaleString()
+}
+
+function Delta({ current, previous }: { current: number; previous: number }) {
+  if (previous === 0) {
+    return <p className={`${styles.kpiDelta} ${styles.deltaFlat}`}>no prior data</p>
+  }
+  const change = ((current - previous) / previous) * 100
+  const className =
+    change > 0.5 ? styles.deltaUp : change < -0.5 ? styles.deltaDown : styles.deltaFlat
+  const arrow = change > 0.5 ? '▲' : change < -0.5 ? '▼' : '■'
+  return (
+    <p className={`${styles.kpiDelta} ${className}`}>
+      {arrow} {Math.abs(change).toFixed(0)}% vs previous period
+    </p>
+  )
+}
+
+export default function KpiCards({ current, previous }: Props) {
+  return (
+    <div className={styles.kpiGrid}>
+      {KPIS.map(({ key, label }) => (
+        <div key={key} className={styles.card}>
+          <p className={styles.kpiLabel}>{label}</p>
+          <p className={styles.kpiValue}>
+            {current ? formatCount(current[key]) : '—'}
+          </p>
+          {current && previous ? (
+            <Delta current={current[key]} previous={previous[key]} />
+          ) : (
+            <p className={`${styles.kpiDelta} ${styles.deltaFlat}`}>…</p>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/alpha-projs/ga-traffic-dashboard/src/components/QualitySection.tsx
+++ b/alpha-projs/ga-traffic-dashboard/src/components/QualitySection.tsx
@@ -1,0 +1,204 @@
+import { useMemo } from 'react'
+import type { PageRow, QualityResponse } from '../api'
+import { groupForPath } from '../appGroups'
+import { formatSeconds, type ChartRow } from '../charts'
+import { formatDateLabel } from '../dates'
+import styles from '../dashboard.module.css'
+import { AppLines } from './AppLineChart'
+
+type Props = {
+  quality: QualityResponse
+  pages: PageRow[]
+  hidden: Set<string>
+}
+
+/**
+ * Session-weighted engagement rate per app per date. Weighting by sessions
+ * keeps one-hit paths from dominating the average.
+ */
+function rateSeries(quality: QualityResponse, rate: 'bounceRate' | 'engagementRate') {
+  const byDate = new Map<string, Map<string, { weighted: number; sessions: number }>>()
+  const totals = new Map<string, number>()
+
+  for (const row of quality.rates) {
+    const group = groupForPath(row.pagePath)
+    totals.set(group, (totals.get(group) ?? 0) + row.sessions)
+    let groups = byDate.get(row.date)
+    if (!groups) {
+      groups = new Map()
+      byDate.set(row.date, groups)
+    }
+    const bucket = groups.get(group) ?? { weighted: 0, sessions: 0 }
+    bucket.weighted += row[rate] * row.sessions
+    bucket.sessions += row.sessions
+    groups.set(group, bucket)
+  }
+
+  const groupNames = [...totals.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([name]) => name)
+
+  const chartData: ChartRow[] = [...byDate.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([date, groups]) => {
+      const row: ChartRow = { date: formatDateLabel(date, quality.granularity) }
+      for (const [name, bucket] of groups) {
+        if (bucket.sessions > 0) {
+          row[name] = Number(((bucket.weighted / bucket.sessions) * 100).toFixed(1))
+        }
+      }
+      return row
+    })
+
+  return { chartData, groupNames }
+}
+
+const AUTOMATION_BROWSERS = /headless|phantom|electron|bot|crawler|spider/i
+
+export default function QualitySection({ quality, pages, hidden }: Props) {
+  const engagement = useMemo(
+    () => rateSeries(quality, 'engagementRate'),
+    [quality],
+  )
+  const bounce = useMemo(() => rateSeries(quality, 'bounceRate'), [quality])
+
+  const timeOnPage = useMemo(
+    () =>
+      pages
+        .filter((row) => row.screenPageViews >= 5)
+        .map((row) => ({
+          ...row,
+          avgSeconds: row.engagementSeconds / row.screenPageViews,
+        }))
+        .sort((a, b) => b.avgSeconds - a.avgSeconds)
+        .slice(0, 12),
+    [pages],
+  )
+
+  const totalSessions = quality.browsers.reduce((sum, b) => sum + b.sessions, 0)
+
+  return (
+    <>
+      <section className={styles.section}>
+        <h2>Engagement rate by app</h2>
+        <p className={styles.sectionNote}>
+          Share of sessions that lasted 10+ seconds, had a key event, or viewed
+          2+ pages. Session-weighted; higher is better.
+        </p>
+        <div className={styles.card}>
+          <AppLines
+            data={engagement.chartData}
+            groupNames={engagement.groupNames}
+            hidden={hidden}
+            height={280}
+          />
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <h2>Bounce rate by app</h2>
+        <p className={styles.sectionNote}>
+          The inverse view: share of sessions with no meaningful engagement.
+        </p>
+        <div className={styles.card}>
+          <AppLines
+            data={bounce.chartData}
+            groupNames={bounce.groupNames}
+            hidden={hidden}
+            height={280}
+          />
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <h2>Time on page</h2>
+        <p className={styles.sectionNote}>
+          Pages people actually stay on: average engaged time per view, pages
+          with 5+ views in range.
+        </p>
+        <div className={`${styles.card} ${styles.tableWrap}`}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>Page</th>
+                <th className={styles.num}>Views</th>
+                <th className={styles.num}>Avg engaged time</th>
+              </tr>
+            </thead>
+            <tbody>
+              {timeOnPage.map((row) => (
+                <tr key={row.pagePath}>
+                  <td className={styles.pathCell} title={row.pagePath}>
+                    {row.pagePath}
+                  </td>
+                  <td className={styles.num}>
+                    {row.screenPageViews.toLocaleString()}
+                  </td>
+                  <td className={styles.num}>{formatSeconds(row.avgSeconds)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <h2>Suspected automation (diagnostic)</h2>
+        <p className={styles.sectionNote}>
+          AI crawlers (GPTBot, ClaudeBot, ...) never execute the analytics tag,
+          so they cannot appear here at all. This table only catches
+          JS-executing automation - headless browsers such as this site&apos;s
+          own PR-screenshot CI. Flagged rows match a known automation browser
+          name or have near-zero engagement across many views.
+        </p>
+        <div className={`${styles.card} ${styles.tableWrap}`}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>Browser</th>
+                <th className={styles.num}>Sessions</th>
+                <th className={styles.num}>Share</th>
+                <th className={styles.num}>Views</th>
+                <th className={styles.num}>Avg engaged time / view</th>
+              </tr>
+            </thead>
+            <tbody>
+              {quality.browsers.map((row) => {
+                const avg =
+                  row.screenPageViews > 0
+                    ? row.engagementSeconds / row.screenPageViews
+                    : 0
+                const flagged =
+                  AUTOMATION_BROWSERS.test(row.browser) ||
+                  (row.screenPageViews >= 20 && avg < 1)
+                return (
+                  <tr
+                    key={row.browser}
+                    className={flagged ? styles.flagged : undefined}
+                  >
+                    <td>
+                      {row.browser}
+                      {flagged ? ' ⚠' : ''}
+                    </td>
+                    <td className={styles.num}>
+                      {row.sessions.toLocaleString()}
+                    </td>
+                    <td className={styles.num}>
+                      {totalSessions > 0
+                        ? `${((row.sessions / totalSessions) * 100).toFixed(1)}%`
+                        : '-'}
+                    </td>
+                    <td className={styles.num}>
+                      {row.screenPageViews.toLocaleString()}
+                    </td>
+                    <td className={styles.num}>{formatSeconds(avg)}</td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </>
+  )
+}

--- a/alpha-projs/ga-traffic-dashboard/src/components/RangePicker.tsx
+++ b/alpha-projs/ga-traffic-dashboard/src/components/RangePicker.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useRef, useState } from 'react'
+import { DayPicker, type DateRange as DayPickerRange } from 'react-day-picker'
+import 'react-day-picker/style.css'
+import {
+  EARLIEST_DATA,
+  PRESETS,
+  fromIso,
+  toIso,
+  type DateRange,
+} from '../dates'
+import styles from '../dashboard.module.css'
+
+type Props = {
+  range: DateRange
+  onChange: (range: DateRange) => void
+}
+
+export default function RangePicker({ range, onChange }: Props) {
+  const [open, setOpen] = useState(false)
+  const [draft, setDraft] = useState<DayPickerRange | undefined>()
+  const popoverRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (event: PointerEvent) => {
+      if (!popoverRef.current?.contains(event.target as Node)) setOpen(false)
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  const activePreset = PRESETS.find((preset) => {
+    const presetRange = preset.range()
+    return presetRange.start === range.start && presetRange.end === range.end
+  })
+
+  return (
+    <div className={styles.rangeBar}>
+      {PRESETS.map((preset) => (
+        <button
+          key={preset.label}
+          type="button"
+          className={
+            activePreset?.label === preset.label
+              ? `${styles.presetButton} ${styles.presetButtonActive}`
+              : styles.presetButton
+          }
+          onClick={() => {
+            setOpen(false)
+            onChange(preset.range())
+          }}
+        >
+          {preset.label}
+        </button>
+      ))}
+      <div className={styles.pickerPopover} ref={popoverRef}>
+        <button
+          type="button"
+          className={
+            open || !activePreset
+              ? `${styles.presetButton} ${styles.presetButtonActive}`
+              : styles.presetButton
+          }
+          onClick={() => {
+            setDraft({ from: fromIso(range.start), to: fromIso(range.end) })
+            setOpen((value) => !value)
+          }}
+        >
+          Custom
+        </button>
+        {open && (
+          <div className={styles.pickerPanel}>
+            <DayPicker
+              mode="range"
+              numberOfMonths={2}
+              selected={draft}
+              defaultMonth={draft?.from}
+              disabled={{ before: EARLIEST_DATA, after: new Date() }}
+              onSelect={setDraft}
+            />
+            <div className={styles.pickerActions}>
+              <button
+                type="button"
+                className={styles.presetButton}
+                onClick={() => setOpen(false)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className={`${styles.presetButton} ${styles.presetButtonActive}`}
+                disabled={!draft?.from}
+                onClick={() => {
+                  if (!draft?.from) return
+                  onChange({
+                    start: toIso(draft.from),
+                    end: toIso(draft.to ?? draft.from),
+                  })
+                  setOpen(false)
+                }}
+              >
+                Apply
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+      <span className={styles.rangeLabel}>
+        {range.start} to {range.end}
+      </span>
+    </div>
+  )
+}

--- a/alpha-projs/ga-traffic-dashboard/src/components/SparklineGrid.tsx
+++ b/alpha-projs/ga-traffic-dashboard/src/components/SparklineGrid.tsx
@@ -1,0 +1,54 @@
+import { Line, LineChart, ResponsiveContainer } from 'recharts'
+import { colorForGroup } from '../appGroups'
+import type { GroupedSeries } from '../charts'
+import styles from '../dashboard.module.css'
+
+type Props = { series: GroupedSeries }
+
+function trendArrow(values: number[]): string {
+  if (values.length < 2) return '■'
+  const half = Math.floor(values.length / 2)
+  const first = values.slice(0, half).reduce((a, b) => a + b, 0)
+  const second = values.slice(half).reduce((a, b) => a + b, 0)
+  if (second > first * 1.1) return '▲'
+  if (second < first * 0.9) return '▼'
+  return '■'
+}
+
+export default function SparklineGrid({ series }: Props) {
+  return (
+    <div className={styles.sparkGrid}>
+      {series.groupNames.map((name) => {
+        const values = series.chartData.map(
+          (row) => (row[name] as number) ?? 0,
+        )
+        const data = values.map((value, index) => ({ index, value }))
+        return (
+          <div key={name} className={styles.sparkCard}>
+            <div className={styles.sparkHead}>
+              <p className={styles.sparkName} style={{ color: colorForGroup(name) }}>
+                {name}
+              </p>
+              <p className={styles.sparkTotal}>
+                {(series.totals.get(name) ?? 0).toLocaleString()}{' '}
+                {trendArrow(values)}
+              </p>
+            </div>
+            <ResponsiveContainer width="100%" height={48}>
+              <LineChart data={data} margin={{ top: 6, right: 2, bottom: 2, left: 2 }}>
+                <Line
+                  type="monotone"
+                  dataKey="value"
+                  stroke={colorForGroup(name)}
+                  strokeWidth={2}
+                  dot={false}
+                  isAnimationActive={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/alpha-projs/ga-traffic-dashboard/src/components/StaticNotice.tsx
+++ b/alpha-projs/ga-traffic-dashboard/src/components/StaticNotice.tsx
@@ -1,0 +1,38 @@
+import styles from '../dashboard.module.css'
+
+// Optional deep link to the GA4 report for this property. Kept out of the
+// repo: set VITE_GA_REPORT_URL in .env.local (see .env.example).
+const GA_REPORT_URL = import.meta.env.VITE_GA_REPORT_URL as string | undefined
+
+export default function StaticNotice() {
+  return (
+    <div className={`${styles.card} ${styles.notice}`}>
+      <h2>This is a static deployment - no data here</h2>
+      <p className={styles.sectionNote}>
+        The charts need a local API server that queries Google Analytics with
+        private credentials, so they only work on your machine. Static hosts
+        like GitHub Pages can&apos;t run it.
+      </p>
+      <p className={styles.sectionNote}>Run it locally:</p>
+      <pre>{`git clone git@github.com:leoncheng57/leoncheng57.github.io.git
+cd leoncheng57.github.io/alpha-projs/ga-traffic-dashboard
+npm install
+cp .env.example .env.local   # fill in your GA4 property + key path
+npm run dev
+# open http://localhost:5199`}</pre>
+      <p className={styles.sectionNote}>
+        {GA_REPORT_URL ? (
+          <>
+            Or view the full data directly in{' '}
+            <a href={GA_REPORT_URL} target="_blank" rel="noreferrer">
+              Google Analytics - Pages and screens
+            </a>
+            .
+          </>
+        ) : (
+          'Or view the full data directly in Google Analytics.'
+        )}
+      </p>
+    </div>
+  )
+}

--- a/alpha-projs/ga-traffic-dashboard/src/components/TopPagesTable.tsx
+++ b/alpha-projs/ga-traffic-dashboard/src/components/TopPagesTable.tsx
@@ -1,0 +1,57 @@
+import type { PageRow } from '../api'
+import { colorForGroup, groupForPath } from '../appGroups'
+import { formatSeconds } from '../charts'
+import styles from '../dashboard.module.css'
+
+type Props = { rows: PageRow[]; limit?: number }
+
+export default function TopPagesTable({ rows, limit = 20 }: Props) {
+  const top = rows.slice(0, limit)
+  return (
+    <div className={`${styles.card} ${styles.tableWrap}`}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>Page</th>
+            <th>App</th>
+            <th className={styles.num}>Views</th>
+            <th className={styles.num}>Users</th>
+            <th className={styles.num}>Avg time / view</th>
+          </tr>
+        </thead>
+        <tbody>
+          {top.map((row) => {
+            const group = groupForPath(row.pagePath)
+            const avg =
+              row.screenPageViews > 0
+                ? row.engagementSeconds / row.screenPageViews
+                : 0
+            return (
+              <tr key={row.pagePath}>
+                <td className={styles.pathCell} title={row.pagePath}>
+                  {row.pagePath}
+                </td>
+                <td>
+                  <span
+                    className={styles.appTag}
+                    style={{
+                      color: colorForGroup(group),
+                      borderColor: colorForGroup(group),
+                    }}
+                  >
+                    {group}
+                  </span>
+                </td>
+                <td className={styles.num}>
+                  {row.screenPageViews.toLocaleString()}
+                </td>
+                <td className={styles.num}>{row.activeUsers.toLocaleString()}</td>
+                <td className={styles.num}>{formatSeconds(avg)}</td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/alpha-projs/ga-traffic-dashboard/src/dashboard.module.css
+++ b/alpha-projs/ga-traffic-dashboard/src/dashboard.module.css
@@ -1,0 +1,351 @@
+:root {
+  --blue-emphasis: #087da8;
+  --link-hover-color: #075985;
+  --bg: #eaf3f4;
+  --surface: #f5f8f7;
+  --text-primary: #10233d;
+  --text-muted: #47617e;
+  --link-color: #087da8;
+  --accent-soft: #d5f0fa;
+  --accent-warm: #f4ad9c;
+}
+
+.page {
+  min-height: 100vh;
+  padding: 2rem 1rem 5rem;
+  font-family: Arial, Helvetica, sans-serif;
+  color: var(--text-primary);
+  background-color: var(--bg);
+  background-image:
+    linear-gradient(rgba(16, 35, 61, 0.12) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(16, 35, 61, 0.12) 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+
+.page a {
+  color: var(--link-color);
+  text-decoration: none;
+}
+
+.page a:hover {
+  color: var(--link-hover-color);
+  text-decoration: underline;
+}
+
+.content {
+  width: min(100%, 68rem);
+  margin: 0 auto;
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--link-color);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.pageHeader {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin: 0.5rem 0 2rem;
+}
+
+.pageHeader h1 {
+  margin: 0.2rem 0 0;
+  font-size: clamp(2rem, 6vw, 3.4rem);
+  line-height: 0.95;
+  letter-spacing: -0.045em;
+}
+
+.headerLinks {
+  font-size: 0.8rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.section {
+  margin-top: 2.5rem;
+}
+
+.section > h2 {
+  margin: 0 0 0.35rem;
+  font-size: clamp(1.25rem, 3.5vw, 1.6rem);
+}
+
+.sectionNote {
+  margin: 0 0 1rem;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.card {
+  padding: 1.25rem;
+  border: 3px solid var(--text-primary);
+  background: var(--surface);
+  box-shadow: 8px 8px 0 var(--text-primary);
+}
+
+/* --- range picker ------------------------------------------------------- */
+
+.rangeBar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.presetButton {
+  padding: 0.35rem 0.8rem;
+  border: 2px solid var(--text-primary);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--text-primary);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.presetButtonActive {
+  background: var(--text-primary);
+  color: var(--surface);
+}
+
+.rangeLabel {
+  margin-left: 0.25rem;
+  color: var(--text-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.78rem;
+}
+
+.pickerPopover {
+  position: relative;
+}
+
+.pickerPanel {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  padding: 0.75rem;
+  border: 3px solid var(--text-primary);
+  background: var(--surface);
+  box-shadow: 8px 8px 0 var(--text-primary);
+}
+
+.pickerPanel :global(.rdp-root) {
+  --rdp-accent-color: #087da8;
+  --rdp-accent-background-color: #d5f0fa;
+  font-size: 0.85rem;
+}
+
+.pickerActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.pickerActions button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* --- KPI cards ---------------------------------------------------------- */
+
+.kpiGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+  gap: 1.5rem;
+}
+
+.kpiLabel {
+  margin: 0;
+  color: var(--text-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.kpiValue {
+  margin: 0.35rem 0 0.15rem;
+  font-size: 2.1rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+}
+
+.kpiDelta {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.deltaUp {
+  color: #15803d;
+}
+
+.deltaDown {
+  color: #b91c1c;
+}
+
+.deltaFlat {
+  color: var(--text-muted);
+}
+
+/* --- app pills ---------------------------------------------------------- */
+
+.pillRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0 0 1rem;
+}
+
+.pill {
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  border: 2px solid;
+  font-size: 0.78rem;
+  font-weight: 700;
+  cursor: pointer;
+  background: transparent;
+}
+
+/* --- sparkline grid ------------------------------------------------------ */
+
+.sparkGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(12.5rem, 1fr));
+  gap: 1.25rem;
+}
+
+.sparkCard {
+  padding: 0.9rem 1rem 0.5rem;
+  border: 3px solid var(--text-primary);
+  background: var(--surface);
+  box-shadow: 6px 6px 0 var(--text-primary);
+}
+
+.sparkHead {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.sparkName {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.sparkTotal {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+/* --- tables -------------------------------------------------------------- */
+
+.tableWrap {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.table th {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 3px solid var(--text-primary);
+  text-align: left;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.table td {
+  padding: 0.45rem 0.75rem;
+  border-bottom: 1px solid rgba(16, 35, 61, 0.15);
+  white-space: nowrap;
+}
+
+.table td.num,
+.table th.num {
+  text-align: right;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.pathCell {
+  max-width: 24rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.78rem;
+}
+
+.appTag {
+  display: inline-block;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  border: 2px solid;
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.flagged {
+  background: #fde8e8;
+}
+
+/* --- states -------------------------------------------------------------- */
+
+.loading {
+  color: var(--text-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.8rem;
+}
+
+.error {
+  padding: 0.75rem 1rem;
+  border: 3px solid #b91c1c;
+  background: #fde8e8;
+  color: #7f1d1d;
+  font-size: 0.9rem;
+}
+
+.notice {
+  max-width: 42rem;
+  margin: 3rem auto;
+}
+
+.notice pre {
+  padding: 0.9rem 1rem;
+  overflow-x: auto;
+  border: 2px solid var(--text-primary);
+  border-radius: 0;
+  background: var(--text-primary);
+  color: #e5e7eb;
+  font-size: 0.8rem;
+  line-height: 1.6;
+}

--- a/alpha-projs/ga-traffic-dashboard/src/dates.ts
+++ b/alpha-projs/ga-traffic-dashboard/src/dates.ts
@@ -1,0 +1,77 @@
+export type DateRange = { start: string; end: string }
+
+export const EARLIEST_DATA = new Date(2022, 4, 25) // 2022-05-25
+
+export function toIso(date: Date): string {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+export function fromIso(iso: string): Date {
+  const [y, m, d] = iso.split('-').map(Number)
+  return new Date(y, m - 1, d)
+}
+
+function daysAgo(days: number): Date {
+  const date = new Date()
+  date.setDate(date.getDate() - days)
+  return date
+}
+
+export type Preset = { label: string; range: () => DateRange }
+
+export const PRESETS: Preset[] = [
+  {
+    label: '7 days',
+    range: () => ({ start: toIso(daysAgo(6)), end: toIso(new Date()) }),
+  },
+  {
+    label: '30 days',
+    range: () => ({ start: toIso(daysAgo(29)), end: toIso(new Date()) }),
+  },
+  {
+    label: '90 days',
+    range: () => ({ start: toIso(daysAgo(89)), end: toIso(new Date()) }),
+  },
+  {
+    label: 'This year',
+    range: () => ({
+      start: toIso(new Date(new Date().getFullYear(), 0, 1)),
+      end: toIso(new Date()),
+    }),
+  },
+  {
+    label: 'All time',
+    range: () => ({ start: toIso(EARLIEST_DATA), end: toIso(new Date()) }),
+  },
+]
+
+export function rangeLengthDays({ start, end }: DateRange): number {
+  const ms = fromIso(end).getTime() - fromIso(start).getTime()
+  return Math.round(ms / 86_400_000) + 1
+}
+
+/** Daily for short ranges, weekly once daily would be unreadable. */
+export function autoGranularity(range: DateRange): 'day' | 'week' {
+  return rangeLengthDays(range) > 120 ? 'week' : 'day'
+}
+
+/** The equal-length period immediately before `range`, for KPI deltas. */
+export function previousPeriod(range: DateRange): DateRange {
+  const days = rangeLengthDays(range)
+  const prevEnd = fromIso(range.start)
+  prevEnd.setDate(prevEnd.getDate() - 1)
+  const prevStart = new Date(prevEnd)
+  prevStart.setDate(prevStart.getDate() - days + 1)
+  return { start: toIso(prevStart), end: toIso(prevEnd) }
+}
+
+export function formatDateLabel(
+  raw: string,
+  granularity: 'day' | 'week',
+): string {
+  if (granularity === 'week') return `${raw.slice(0, 4)}-W${raw.slice(4)}`
+  return `${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6)}`
+}


### PR DESCRIPTION
## What

Rebuilds the local-only GA traffic dashboard (`alpha-projs/ga-traffic-dashboard/`) into a single scrollable page, adds a demo mode, and updates the site's alpha-projs pages.

### Dashboard page, top to bottom

1. **Date range picker** - `react-day-picker` presets (7d / 30d / 90d / This year / All time back to 2022-05-25) plus an Apply-confirmed custom range. Granularity switches daily/weekly automatically at 120 days; the old metric and granularity dropdowns are gone.
2. **KPI cards** - views / active users / sessions with % delta vs the previous equal-length period
3. **Views / Active users / Sessions by app** - three separate per-app line charts
4. **Share of traffic** - 100% stacked area
5. **Per-app trend** - sparkline grid with totals and trend arrows
6. **Top pages** - table with app tag, views, users, avg time per view
7. **Engagement rate / Bounce rate by app** - session-weighted lines
8. **Time on page** - pages ranked by avg engaged time per view
9. **Suspected automation (diagnostic only)** - browser breakdown with flagged rows. AI crawlers never execute the analytics tag so they cannot appear in GA; this catches JS-executing automation (it flagged the repo's own PR-screenshot CI in real data).

### Demo mode

`localhost:5199/?demo` serves deterministic **generated** data for every endpoint, with a `DEMO DATA` badge in the header - so the UI can be previewed and screenshotted without credentials and without exposing real traffic.

### Site changes

- **Alpha Projs card**: `local-only` pill next to the Alpha badge
- **Detail page** gains a "What it looks like" section with two committed screenshots: the full demo page (fake numbers only, badge visible) and the static degradation notice (no data at all)

### Implementation

- Server: shared `runReport` helper, 5-minute cache, date validation, four endpoints (`/api/traffic` returns all three volume metrics from one GA call; new `/api/summary`, `/api/pages`, `/api/quality`)
- UI split into components with a CSS module in the leoncheng.dev visual language
- New dependency: `react-day-picker`

## Privacy

- No property IDs, key paths, or real traffic numbers in the diff (grep-verified)
- The two committed screenshots contain only generated demo numbers (self-labelled with the badge) and the credential-free static notice

## Testing

- Dashboard folder + site root builds pass; root lint passes; route tests cover the new pill and screenshot imgs (full suite green on a quiet machine; a handful of unrelated sub-wait/tuzi/workout-lab tests are load-flaky locally and pass in isolation - CI is authoritative)
- Verified live: all 10 sections with real data, `?demo` with generated data, custom range via two clicks + Apply, All-time weekly over 4+ years, degraded static mode

```screenshots
/repo/alpha-projs
/repo/alpha-projs/ga-traffic-dashboard
```