### PR TITLE
guides: agent dashboard - status protocol and local status board for parallel child agents

### DIFF
--- a/alpha-projs/agent-dashboard/.gitignore
+++ b/alpha-projs/agent-dashboard/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+agent-dashboard.config.json

--- a/alpha-projs/agent-dashboard/README.md
+++ b/alpha-projs/agent-dashboard/README.md
@@ -1,0 +1,77 @@
+# Agent Dashboard (alpha, local-only)
+
+One view of every child agent working in parallel. Each child writes a small
+`.agent-status.json` at the root of its own git worktree on every phase change;
+this CLI collects those files and joins them with git, GitHub, and cmux state to
+print one row per child.
+
+It is intentionally **not deployed**: the thing it reports on is a set of
+worktrees on one laptop, so a static host has nothing to point it at.
+
+## Run
+
+```bash
+cd alpha-projs/agent-dashboard
+node cli.mjs            # one-shot table
+node cli.mjs --watch    # live board, redrawn every 5s, ctrl-c to exit
+node cli.mjs --json     # aggregated state for scripts and agents
+```
+
+No install step and no config file: there are no dependencies, and the project
+is inferred from the current directory. Requires Node 22 or newer.
+
+```text
+leoncheng.dev  base main
+5 children  1 blocked  1 stale  1 done  4:04:29 PM
+
+CHILD                 PHASE      AGE  BRANCH                      CI    PR    WORKSPACE     NOTES
+auth-guard            working    2h   refactor/auth-guard         -     -     -             extracting the guar…
+search-filters        blocked    6m   feat/search-filters         -     -     -             needs a decision on…
+manager-worker-guide  verifying  1m   blog/manager-worker-ag… +9  pass  #175  -             running lint, tests…
+Agent Dashboard 2     pr-open    4m   guides/agent-dashbo… +7/-5  pass  #192  workspace:39  draft PR open, awai…
+gmail-screenshot      done       42m  alpha-projs/gmail-r… +1/-1  pass  #191  -             merged
+```
+
+Rows sort worst-first - stale, then by phase - so the top of the table is the
+shortest description of what still needs attention.
+
+## Flags
+
+| Flag | Meaning |
+| --- | --- |
+| `--watch` | Live board in the alternate screen buffer, restored cleanly on ctrl-c |
+| `--json` | Print the aggregated state and exit |
+| `--config <path>` | Use this config file instead of auto-detection |
+| `--project <name>` | Select one project from a multi-project config |
+| `--interval <seconds>` | Redraw interval for `--watch` (default 5) |
+| `--help` | Usage |
+
+## Auto-detection
+
+With no config file, the project is inferred from the current directory:
+
+- **root** - the main clone, from `git rev-parse --git-common-dir`, so this works
+  from inside a linked worktree too
+- **name** - that directory's basename
+- **mainBranch** - `origin/HEAD`, falling back to `main`
+- **worktrees** - `<parent of root>/<name>.worktrees/*`
+- **github** - owner and repo parsed from the `origin` remote
+
+Copy `agent-dashboard.config.example.json` to `agent-dashboard.config.json` to
+override any of those, or to track several projects via a `projects` array. The
+config file is gitignored because its values are local paths.
+
+## Degrading
+
+`cmux` and `gh` are optional. When either is missing or fails, its columns show
+`-` and the reason is printed as a single note under the table. Only git and the
+status files are required.
+
+## Privacy rules for this folder
+
+- No status files, worktree paths, or config with local paths may be committed -
+  copy the example config to `agent-dashboard.config.json` instead.
+- The collector reads only `.agent-status.json`; it never reads agent
+  transcripts, and it never writes to a child's worktree.
+
+Full walkthrough: [the Agent Dashboard guide](https://leoncheng.dev/guides/agent-dashboard).

--- a/alpha-projs/agent-dashboard/agent-dashboard.config.example.json
+++ b/alpha-projs/agent-dashboard/agent-dashboard.config.example.json
@@ -1,0 +1,8 @@
+{
+  "name": "leoncheng.dev",
+  "root": "/Users/you/code/leoncheng57.github.io",
+  "mainBranch": "main",
+  "worktrees": "/Users/you/code/leoncheng57.github.io.worktrees/*",
+  "github": { "owner": "leoncheng57", "repo": "leoncheng57.github.io" },
+  "staleAfterSeconds": 900
+}

--- a/alpha-projs/agent-dashboard/cli.mjs
+++ b/alpha-projs/agent-dashboard/cli.mjs
@@ -1,0 +1,940 @@
+#!/usr/bin/env node
+
+// Agent dashboard: one view of every child agent working in its own worktree.
+//
+// Zero dependencies on purpose. The thing this reports on is a set of local
+// worktrees, so it should run from a fresh clone with no install step, and it
+// should keep working when cmux or gh are missing.
+//
+//   node cli.mjs            one-shot table
+//   node cli.mjs --watch    live board, redraw every 5s
+//   node cli.mjs --json     aggregated state for scripts and agents
+
+import { execFileSync } from 'node:child_process'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { parseArgs } from 'node:util'
+
+const CACHE_TTL_MS = 5000
+const DEFAULT_INTERVAL_SECONDS = 5
+const DEFAULT_STALE_AFTER_SECONDS = 900
+const STATUS_FILE = '.agent-status.json'
+const CHILD_TITLE_PREFIX = 'Child:'
+const SUBPROCESS_TIMEOUT_MS = 10000
+const PR_LIMIT = 30
+
+// ---------------------------------------------------------------------------
+// Arguments
+
+const USAGE = `Agent dashboard - one row per child agent.
+
+Usage
+  node cli.mjs [options]
+
+Options
+  --watch              Live full-screen board, redrawn on an interval
+  --json               Print the aggregated state as JSON and exit
+  --config <path>      Config file to use instead of auto-detection
+  --project <name>     Select one project from a multi-project config
+  --interval <seconds> Redraw interval for --watch (default ${DEFAULT_INTERVAL_SECONDS})
+  --help               Show this message
+
+With no config file the project is inferred from the current directory.`
+
+function parseCliArgs(argv) {
+  try {
+    const { values } = parseArgs({
+      args: argv,
+      options: {
+        watch: { type: 'boolean', default: false },
+        json: { type: 'boolean', default: false },
+        config: { type: 'string' },
+        project: { type: 'string' },
+        interval: { type: 'string' },
+        help: { type: 'boolean', default: false },
+      },
+      strict: true,
+    })
+    return values
+  } catch (error) {
+    fail(`${error.message}\n\n${USAGE}`)
+  }
+}
+
+function fail(message) {
+  process.stderr.write(`${message}\n`)
+  process.exit(1)
+}
+
+// ---------------------------------------------------------------------------
+// Subprocess helper with a short cache
+//
+// One render pass asks for the same git and gh data more than once, and --watch
+// repeats the whole pass on an interval. A short TTL keeps both cheap without
+// making the board lag behind reality.
+
+const cache = new Map()
+
+function run(command, args, options = {}) {
+  const key = `${options.cwd ?? '.'}|${command} ${args.join(' ')}`
+  const hit = cache.get(key)
+
+  if (hit && Date.now() - hit.at < CACHE_TTL_MS) {
+    return hit.value
+  }
+
+  // A missing cwd raises ENOENT too, which would otherwise be reported as a
+  // missing tool. Check it first so the note names the real problem.
+  if (options.cwd && !directoryExists(options.cwd)) {
+    const value = {
+      ok: false,
+      missing: false,
+      stdout: '',
+      error: `directory does not exist: ${options.cwd}`,
+    }
+    cache.set(key, { at: Date.now(), value })
+    return value
+  }
+
+  let value
+  try {
+    value = {
+      ok: true,
+      stdout: execFileSync(command, args, {
+        cwd: options.cwd,
+        encoding: 'utf8',
+        timeout: SUBPROCESS_TIMEOUT_MS,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        maxBuffer: 16 * 1024 * 1024,
+      }).trim(),
+    }
+  } catch (error) {
+    value = {
+      ok: false,
+      // ENOENT means the tool is not installed, which is a different problem
+      // from the tool refusing to answer.
+      missing: error.code === 'ENOENT',
+      stdout: '',
+      error: String(error.stderr || error.message || error).trim(),
+    }
+  }
+
+  cache.set(key, { at: Date.now(), value })
+  return value
+}
+
+function runJson(command, args, options = {}) {
+  const result = run(command, args, options)
+  if (!result.ok) return result
+
+  try {
+    return { ok: true, data: JSON.parse(result.stdout) }
+  } catch (error) {
+    return { ok: false, missing: false, error: `unparseable JSON: ${error.message}` }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Project resolution
+//
+// Auto-detection reads the repository the current directory belongs to, so the
+// common case needs no config at all.
+
+function detectProject(fromDirectory) {
+  // --git-common-dir resolves to the main clone even when run inside a linked
+  // worktree, which is where this usually runs.
+  const commonDir = run('git', ['rev-parse', '--path-format=absolute', '--git-common-dir'], {
+    cwd: fromDirectory,
+  })
+
+  if (!commonDir.ok) return null
+
+  const mainRoot = path.dirname(commonDir.stdout)
+  const name = path.basename(mainRoot)
+
+  const originHead = run('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], { cwd: mainRoot })
+  const mainBranch = originHead.ok
+    ? originHead.stdout.replace('refs/remotes/origin/', '')
+    : 'main'
+
+  const originUrl = run('git', ['remote', 'get-url', 'origin'], { cwd: mainRoot })
+
+  return {
+    name,
+    root: mainRoot,
+    mainBranch,
+    // Canonical layout: the main clone and a sibling directory of worktrees.
+    worktrees: path.join(path.dirname(mainRoot), `${name}.worktrees`, '*'),
+    github: originUrl.ok ? parseGithubRemote(originUrl.stdout) : null,
+    detected: true,
+  }
+}
+
+/** Accepts both SSH (git@host:owner/repo.git) and HTTPS remote forms. */
+function parseGithubRemote(url) {
+  const match = url.match(/[/:]([^/:]+)\/([^/]+?)(?:\.git)?$/)
+  return match ? { owner: match[1], repo: match[2] } : null
+}
+
+function loadConfigFile(explicitPath, scriptDirectory) {
+  const candidates = explicitPath
+    ? [path.resolve(explicitPath)]
+    : [path.join(process.cwd(), 'agent-dashboard.config.json'),
+       path.join(scriptDirectory, 'agent-dashboard.config.json')]
+
+  for (const candidate of candidates) {
+    let raw
+    try {
+      raw = readFileSync(candidate, 'utf8')
+    } catch {
+      continue
+    }
+
+    try {
+      return { path: candidate, data: JSON.parse(raw) }
+    } catch (error) {
+      // A config that exists but cannot be read is a mistake worth stopping
+      // for; silently falling back to auto-detection would hide it.
+      fail(`${candidate} could not be parsed: ${error.message}`)
+    }
+  }
+
+  return null
+}
+
+function resolveProject(values, scriptDirectory) {
+  const file = loadConfigFile(values.config, scriptDirectory)
+
+  if (!file) {
+    if (values.project) {
+      fail(`--project ${values.project} needs a config file, and none was found.`)
+    }
+
+    const detected = detectProject(process.cwd()) ?? detectProject(scriptDirectory)
+
+    if (!detected) {
+      fail(
+        'Could not detect a project: the current directory is not inside a Git repository.\n' +
+          'Run this from a repository, or pass --config with a config file.'
+      )
+    }
+
+    return detected
+  }
+
+  const configured = Array.isArray(file.data.projects) ? file.data.projects : [file.data]
+  const selected = values.project
+    ? configured.find((project) => project.name === values.project)
+    : configured[0]
+
+  if (!selected) {
+    const names = configured.map((project) => project.name ?? '(unnamed)').join(', ')
+    fail(`No project named "${values.project}" in ${file.path}. Available: ${names}`)
+  }
+
+  // Anything the config leaves out still falls back to auto-detection.
+  const base = detectProject(selected.root ?? process.cwd()) ?? {}
+
+  return {
+    name: selected.name ?? base.name ?? 'project',
+    root: selected.root ? path.resolve(selected.root) : base.root,
+    mainBranch: selected.mainBranch ?? base.mainBranch ?? 'main',
+    worktrees: selected.worktrees
+      ? path.resolve(selected.worktrees)
+      : base.worktrees,
+    github: selected.github ?? base.github ?? null,
+    staleAfterSeconds: selected.staleAfterSeconds,
+    detected: false,
+    configPath: file.path,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sources
+
+/** Supports the trailing `/*` form used by the worktrees setting. */
+function expandGlob(pattern) {
+  if (!pattern) return []
+
+  if (!pattern.endsWith(`${path.sep}*`) && !pattern.endsWith('/*')) {
+    return directoryExists(pattern) ? [pattern] : []
+  }
+
+  const base = pattern.slice(0, -2)
+
+  try {
+    return readdirSync(base, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && !entry.name.startsWith('.'))
+      .map((entry) => path.join(base, entry.name))
+      .sort()
+  } catch {
+    return []
+  }
+}
+
+function directoryExists(candidate) {
+  try {
+    return statSync(candidate).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+function readStatusFile(directory, staleAfterSeconds) {
+  let raw
+  try {
+    raw = readFileSync(path.join(directory, STATUS_FILE), 'utf8')
+  } catch {
+    return null
+  }
+
+  const id = path.basename(directory)
+
+  let parsed
+  try {
+    parsed = JSON.parse(raw)
+  } catch (error) {
+    // Usually a half-written file caught mid-poll. Keep the row: a child that
+    // vanishes from the board is a worse failure than one that shows up broken.
+    return {
+      id,
+      worktree: directory,
+      task: id,
+      phase: 'invalid',
+      branch: null,
+      prUrl: null,
+      summary: '',
+      blockers: [],
+      updatedAt: null,
+      ageSeconds: null,
+      stale: false,
+      note: `unparseable ${STATUS_FILE}: ${error.message}`,
+    }
+  }
+
+  const updatedAt = parsed.updated_at ?? parsed.updatedAt ?? null
+  const updatedMs = updatedAt ? Date.parse(updatedAt) : Number.NaN
+  const ageSeconds = Number.isNaN(updatedMs)
+    ? null
+    : Math.max(0, Math.round((Date.now() - updatedMs) / 1000))
+  const phase = typeof parsed.phase === 'string' ? parsed.phase : 'unknown'
+
+  return {
+    id,
+    worktree: directory,
+    task: parsed.task ?? id,
+    phase,
+    branch: parsed.branch ?? null,
+    prUrl: parsed.pr_url ?? parsed.prUrl ?? null,
+    summary: parsed.summary ?? parsed.notes ?? '',
+    blockers: Array.isArray(parsed.blockers) ? parsed.blockers : [],
+    updatedAt,
+    ageSeconds,
+    stale:
+      ageSeconds !== null && ageSeconds > staleAfterSeconds && phase !== 'done',
+    note: null,
+  }
+}
+
+function readCmuxWorkspaces() {
+  const result = runJson('cmux', ['workspace', 'list', '--json'])
+
+  if (!result.ok) {
+    return {
+      available: false,
+      note: result.missing
+        ? 'cmux not on PATH'
+        : `cmux workspace list failed: ${firstLine(result.error)}`,
+      workspaces: [],
+    }
+  }
+
+  const all = Array.isArray(result.data) ? result.data : (result.data.workspaces ?? [])
+
+  return {
+    available: true,
+    note: null,
+    workspaces: all
+      .map((workspace) => ({
+        ref: workspace.ref ?? workspace.id ?? null,
+        title: workspace.title ?? workspace.custom_title ?? '',
+        directory: workspace.current_directory ?? null,
+      }))
+      .filter((workspace) => workspace.title.startsWith(CHILD_TITLE_PREFIX)),
+  }
+}
+
+function readPullRequests(project) {
+  // statusCheckRollup is the expensive part of this query, so the limit stays
+  // small: children are always among the most recent pull requests.
+  const args = [
+    'pr',
+    'list',
+    '--state',
+    'all',
+    '--limit',
+    String(PR_LIMIT),
+    '--json',
+    'number,title,state,isDraft,url,headRefName,statusCheckRollup',
+  ]
+
+  if (project.github) {
+    args.push('--repo', `${project.github.owner}/${project.github.repo}`)
+  }
+
+  const result = runJson('gh', args, { cwd: project.root })
+
+  if (!result.ok) {
+    return {
+      available: false,
+      note: result.missing
+        ? 'gh not on PATH'
+        : `gh pr list failed: ${firstLine(result.error)}`,
+      byBranch: new Map(),
+    }
+  }
+
+  const byBranch = new Map()
+
+  for (const pr of result.data) {
+    // gh returns newest first; keep the newest per branch, preferring open ones.
+    const existing = byBranch.get(pr.headRefName)
+    if (existing && existing.state === 'OPEN' && pr.state !== 'OPEN') continue
+
+    byBranch.set(pr.headRefName, {
+      number: pr.number,
+      state: pr.state,
+      isDraft: pr.isDraft,
+      url: pr.url,
+      ci: rollupToCiState(pr.statusCheckRollup),
+    })
+  }
+
+  return { available: true, note: null, byBranch }
+}
+
+/** Collapses a GitHub status-check rollup into one word. */
+function rollupToCiState(rollup) {
+  if (!Array.isArray(rollup) || rollup.length === 0) return 'none'
+
+  const outcomes = rollup.map((check) =>
+    String(check.conclusion || check.state || check.status || '').toUpperCase()
+  )
+
+  if (outcomes.some((outcome) => ['FAILURE', 'ERROR', 'TIMED_OUT', 'CANCELLED'].includes(outcome))) {
+    return 'failing'
+  }
+
+  if (
+    rollup.some((check) =>
+      ['IN_PROGRESS', 'QUEUED', 'PENDING', 'WAITING', 'REQUESTED'].includes(
+        String(check.status || check.state || '').toUpperCase()
+      )
+    )
+  ) {
+    return 'pending'
+  }
+
+  if (outcomes.every((outcome) => ['SUCCESS', 'NEUTRAL', 'SKIPPED'].includes(outcome))) {
+    return 'passing'
+  }
+
+  return 'unknown'
+}
+
+function readAheadBehind(project, branch) {
+  if (!branch || !project.root) return { available: false, ahead: null, behind: null }
+
+  // Compare against the remote main when it is available, because that is what
+  // the branch will actually merge into.
+  const remoteMain = `origin/${project.mainBranch}`
+  const base = run('git', ['rev-parse', '--verify', '--quiet', remoteMain], {
+    cwd: project.root,
+  }).ok
+    ? remoteMain
+    : project.mainBranch
+
+  const result = run(
+    'git',
+    ['rev-list', '--left-right', '--count', `${base}...${branch}`],
+    { cwd: project.root }
+  )
+
+  if (!result.ok) return { available: false, ahead: null, behind: null, base }
+
+  const [behind, ahead] = result.stdout.split(/\s+/).map(Number)
+
+  return {
+    available: Number.isFinite(ahead) && Number.isFinite(behind),
+    ahead: Number.isFinite(ahead) ? ahead : null,
+    behind: Number.isFinite(behind) ? behind : null,
+    base,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation
+
+const PHASE_ORDER = [
+  'invalid',
+  'blocked',
+  'no-report',
+  'unknown',
+  'assigned',
+  'working',
+  'verifying',
+  'pushed',
+  'pr-open',
+  'done',
+]
+
+function normalize(value) {
+  return String(value ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '')
+}
+
+function matchWorkspace(child, workspaces) {
+  // Directory is the strongest signal; the title is a fallback for children
+  // whose pane has moved somewhere else in the tree.
+  const byDirectory = workspaces.find(
+    (workspace) =>
+      workspace.directory &&
+      (workspace.directory === child.worktree ||
+        workspace.directory.startsWith(`${child.worktree}${path.sep}`))
+  )
+
+  if (byDirectory) return byDirectory
+
+  const wanted = [normalize(child.id), normalize(child.task)]
+
+  return workspaces.find((workspace) => {
+    const label = normalize(workspace.title.slice(CHILD_TITLE_PREFIX.length))
+    return label.length > 0 && wanted.some((candidate) => candidate === label)
+  })
+}
+
+function aggregate(project) {
+  const staleAfterSeconds = project.staleAfterSeconds ?? DEFAULT_STALE_AFTER_SECONDS
+  const notes = []
+
+  const cmux = readCmuxWorkspaces()
+  const pullRequests = readPullRequests(project)
+
+  if (cmux.note) notes.push(cmux.note)
+  if (pullRequests.note) notes.push(pullRequests.note)
+
+  const directories = expandGlob(project.worktrees)
+
+  if (directories.length === 0) {
+    notes.push(`no worktrees found at ${project.worktrees}`)
+  }
+
+  const children = []
+  const claimedWorkspaces = new Set()
+
+  for (const directory of directories) {
+    const child = readStatusFile(directory, staleAfterSeconds)
+    if (!child) continue
+
+    const workspace = matchWorkspace(child, cmux.workspaces)
+    if (workspace) claimedWorkspaces.add(workspace.ref)
+
+    const pr = child.branch ? pullRequests.byBranch.get(child.branch) : undefined
+
+    children.push({
+      ...child,
+      git: readAheadBehind(project, child.branch),
+      ci: { state: pr?.ci ?? 'none', available: pullRequests.available },
+      pr: pr
+        ? { number: pr.number, state: pr.state, isDraft: pr.isDraft, url: pr.url }
+        : null,
+      cmux: workspace ? { ref: workspace.ref, title: workspace.title } : null,
+    })
+  }
+
+  // A Child: workspace with no status file is its own failure mode: the child
+  // was created but never reported, so it must not be invisible here.
+  for (const workspace of cmux.workspaces) {
+    if (claimedWorkspaces.has(workspace.ref)) continue
+
+    children.push({
+      id: workspace.title.slice(CHILD_TITLE_PREFIX.length).trim() || workspace.ref,
+      worktree: workspace.directory,
+      task: workspace.title.slice(CHILD_TITLE_PREFIX.length).trim(),
+      phase: 'no-report',
+      branch: null,
+      prUrl: null,
+      summary: '',
+      blockers: [],
+      updatedAt: null,
+      ageSeconds: null,
+      stale: false,
+      note: `no ${STATUS_FILE} found for this workspace`,
+      git: { available: false, ahead: null, behind: null },
+      ci: { state: 'none', available: pullRequests.available },
+      pr: null,
+      cmux: { ref: workspace.ref, title: workspace.title },
+    })
+  }
+
+  children.sort((left, right) => {
+    if (left.stale !== right.stale) return left.stale ? -1 : 1
+
+    const leftRank = PHASE_ORDER.indexOf(left.phase)
+    const rightRank = PHASE_ORDER.indexOf(right.phase)
+    const rankDelta =
+      (leftRank === -1 ? PHASE_ORDER.length : leftRank) -
+      (rightRank === -1 ? PHASE_ORDER.length : rightRank)
+
+    return rankDelta || String(left.id).localeCompare(String(right.id))
+  })
+
+  return {
+    generatedAt: new Date().toISOString(),
+    project: {
+      name: project.name,
+      root: project.root,
+      mainBranch: project.mainBranch,
+      worktrees: project.worktrees,
+      github: project.github,
+      source: project.detected ? 'auto-detected' : project.configPath,
+    },
+    staleAfterSeconds,
+    counts: {
+      total: children.length,
+      blocked: children.filter((child) => child.phase === 'blocked').length,
+      stale: children.filter((child) => child.stale).length,
+      done: children.filter((child) => child.phase === 'done').length,
+    },
+    sources: {
+      cmux: { available: cmux.available },
+      gh: { available: pullRequests.available },
+    },
+    notes,
+    children,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+
+const useColor = process.stdout.isTTY && !process.env.NO_COLOR
+
+const C = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  magenta: '\x1b[35m',
+  cyan: '\x1b[36m',
+  gray: '\x1b[90m',
+}
+
+function paint(text, ...codes) {
+  if (!useColor || codes.length === 0) return text
+  return `${codes.join('')}${text}${C.reset}`
+}
+
+const PHASE_COLORS = {
+  invalid: [C.bold, C.red],
+  blocked: [C.bold, C.red],
+  'no-report': [C.bold, C.yellow],
+  unknown: [C.yellow],
+  assigned: [C.gray],
+  working: [C.cyan],
+  verifying: [C.yellow],
+  pushed: [C.magenta],
+  'pr-open': [C.blue],
+  done: [C.green],
+}
+
+const CI_LABELS = {
+  passing: ['pass', [C.green]],
+  failing: ['fail', [C.bold, C.red]],
+  pending: ['run', [C.yellow]],
+  unknown: ['?', [C.gray]],
+  none: ['-', [C.gray]],
+}
+
+const ANSI_PATTERN = /\x1b\[[0-9;]*m/g
+
+function visibleWidth(text) {
+  return text.replace(ANSI_PATTERN, '').length
+}
+
+function padVisible(text, width) {
+  return text + ' '.repeat(Math.max(0, width - visibleWidth(text)))
+}
+
+function truncate(text, width) {
+  const plain = String(text ?? '')
+  if (plain.length <= width) return plain
+  return width <= 1 ? plain.slice(0, width) : `${plain.slice(0, width - 1)}…`
+}
+
+function formatAge(child) {
+  if (child.ageSeconds === null) return paint('-', C.gray)
+
+  const seconds = child.ageSeconds
+  const label =
+    seconds < 60
+      ? `${seconds}s`
+      : seconds < 3600
+        ? `${Math.floor(seconds / 60)}m`
+        : seconds < 86400
+          ? `${Math.floor(seconds / 3600)}h`
+          : `${Math.floor(seconds / 86400)}d`
+
+  return child.stale ? paint(label, C.bold, C.red) : label
+}
+
+function formatBranch(child, width) {
+  if (!child.branch) return paint('-', C.gray)
+
+  const counts = []
+  if (child.git.available) {
+    if (child.git.ahead) counts.push(paint(`+${child.git.ahead}`, C.green))
+    if (child.git.behind) counts.push(paint(`-${child.git.behind}`, C.yellow))
+  }
+
+  const suffix = counts.length > 0 ? ` ${counts.join('/')}` : ''
+  const room = width - visibleWidth(suffix)
+
+  return `${truncate(child.branch, Math.max(3, room))}${suffix}`
+}
+
+function formatPr(child) {
+  if (!child.pr) return paint('-', C.gray)
+
+  const label = `#${child.pr.number}`
+
+  if (child.pr.state === 'MERGED') return paint(label, C.magenta)
+  if (child.pr.state === 'CLOSED') return paint(label, C.gray)
+  return child.pr.isDraft ? paint(label, C.dim) : paint(label, C.bold, C.blue)
+}
+
+/** Returns plain text plus its colour, so the caller can truncate safely. */
+function formatNotes(child) {
+  if (child.blockers.length > 0) {
+    return { text: child.blockers.join('; '), codes: [C.red] }
+  }
+  if (child.note) return { text: child.note, codes: [C.yellow] }
+  return { text: child.summary ?? '', codes: [C.gray] }
+}
+
+function renderTable(state, terminalWidth) {
+  const rows = state.children.map((child) => ({
+    child: truncate(child.task || child.id, 26),
+    phase: paint(child.phase, ...(PHASE_COLORS[child.phase] ?? [C.gray])),
+    age: formatAge(child),
+    branch: child,
+    ci: (() => {
+      const [label, codes] = CI_LABELS[child.ci.state] ?? CI_LABELS.none
+      return paint(child.ci.available ? label : '-', ...codes)
+    })(),
+    pr: formatPr(child),
+    workspace: child.cmux ? child.cmux.ref : paint('-', C.gray),
+    notes: formatNotes(child),
+  }))
+
+  const headers = ['CHILD', 'PHASE', 'AGE', 'BRANCH', 'CI', 'PR', 'WORKSPACE']
+  const widths = [
+    Math.max(5, ...rows.map((row) => visibleWidth(row.child))),
+    Math.max(5, ...rows.map((row) => visibleWidth(row.phase))),
+    Math.max(3, ...rows.map((row) => visibleWidth(row.age))),
+    0,
+    Math.max(2, ...rows.map((row) => visibleWidth(row.ci))),
+    Math.max(2, ...rows.map((row) => visibleWidth(row.pr))),
+    Math.max(9, ...rows.map((row) => visibleWidth(row.workspace))),
+  ]
+
+  const fixed = widths.reduce((total, width) => total + width, 0) + headers.length * 2
+  // Branch takes what is left, and notes get whatever survives after that.
+  const branchWidth = Math.max(12, Math.min(34, terminalWidth - fixed - 20))
+  widths[3] = branchWidth
+
+  const prefixes = rows.map((row) =>
+    [
+      row.child,
+      row.phase,
+      row.age,
+      formatBranch(row.branch, branchWidth),
+      row.ci,
+      row.pr,
+      row.workspace,
+    ]
+      .map((cell, index) => padVisible(cell, widths[index]))
+      .join('  ')
+  )
+
+  const headerPrefix = headers
+    .map((header, index) => padVisible(header, widths[index]))
+    .join('  ')
+
+  // Notes only get a column when there is real room for them, so a narrow
+  // terminal drops the column instead of wrapping the table.
+  const prefixWidth = Math.max(
+    visibleWidth(headerPrefix),
+    ...prefixes.map((prefix) => visibleWidth(prefix))
+  )
+  const notesWidth = terminalWidth - prefixWidth - 2
+  const showNotes = notesWidth >= 12
+
+  const lines = [
+    paint(showNotes ? `${headerPrefix}  NOTES` : headerPrefix, C.bold, C.gray),
+  ]
+
+  rows.forEach((row, index) => {
+    const prefix = prefixes[index]
+
+    if (!showNotes || row.notes.text.length === 0) {
+      lines.push(prefix)
+      return
+    }
+
+    lines.push(
+      `${prefix}  ${paint(truncate(row.notes.text, notesWidth), ...row.notes.codes)}`
+    )
+  })
+
+  return lines
+}
+
+function renderHeader(state) {
+  const { counts } = state
+  const summary = [
+    `${counts.total} ${counts.total === 1 ? 'child' : 'children'}`,
+    counts.blocked > 0
+      ? paint(`${counts.blocked} blocked`, C.bold, C.red)
+      : `${counts.blocked} blocked`,
+    counts.stale > 0
+      ? paint(`${counts.stale} stale`, C.bold, C.red)
+      : `${counts.stale} stale`,
+    `${counts.done} done`,
+  ].join('  ')
+
+  return [
+    `${paint(state.project.name, C.bold)}  ${paint(`base ${state.project.mainBranch}`, C.gray)}`,
+    `${summary}  ${paint(new Date(state.generatedAt).toLocaleTimeString(), C.gray)}`,
+  ]
+}
+
+function renderFrame(state, terminalWidth) {
+  const lines = [...renderHeader(state), '']
+
+  if (state.children.length === 0) {
+    lines.push(
+      paint(
+        `No children reporting yet. Children write ${STATUS_FILE} at the root of their worktree.`,
+        C.gray
+      )
+    )
+  } else {
+    lines.push(...renderTable(state, terminalWidth))
+  }
+
+  // Degraded sources are worth one quiet line, not a missing column with no
+  // explanation.
+  for (const note of state.notes) {
+    lines.push(paint(`note: ${note}`, C.yellow))
+  }
+
+  return lines
+}
+
+function firstLine(text) {
+  return String(text ?? '').split('\n')[0].trim()
+}
+
+// ---------------------------------------------------------------------------
+// Watch mode
+
+function watch(project, intervalSeconds) {
+  const out = process.stdout
+  let active = false
+
+  const enter = () => {
+    if (active) return
+    active = true
+    out.write('\x1b[?1049h\x1b[?25l')
+  }
+
+  const restore = () => {
+    if (!active) return
+    active = false
+    out.write('\x1b[?25h\x1b[?1049l')
+  }
+
+  const draw = () => {
+    const state = aggregate(project)
+    const width = out.columns || 120
+    const height = out.rows || 40
+    const lines = renderFrame(state, width)
+    lines.push('', paint(`refreshing every ${intervalSeconds}s - ctrl-c to exit`, C.gray))
+
+    // One write per frame, and the clear is part of it, so the board does not
+    // flicker between erase and redraw.
+    out.write(`\x1b[H\x1b[2J${lines.slice(0, height - 1).join('\n')}\n`)
+  }
+
+  enter()
+  draw()
+
+  const timer = setInterval(draw, Math.max(1, intervalSeconds) * 1000)
+  const stop = (code) => {
+    clearInterval(timer)
+    restore()
+    process.exit(code)
+  }
+
+  process.on('SIGINT', () => stop(130))
+  process.on('SIGTERM', () => stop(143))
+  process.on('exit', restore)
+  process.on('uncaughtException', (error) => {
+    restore()
+    process.stderr.write(`${error.stack ?? error}\n`)
+    process.exit(1)
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+
+function main() {
+  const values = parseCliArgs(process.argv.slice(2))
+
+  if (values.help) {
+    process.stdout.write(`${USAGE}\n`)
+    return
+  }
+
+  const scriptDirectory = path.dirname(fileURLToPath(import.meta.url))
+  const project = resolveProject(values, scriptDirectory)
+
+  if (values.json) {
+    process.stdout.write(`${JSON.stringify(aggregate(project), null, 2)}\n`)
+    return
+  }
+
+  if (values.watch) {
+    const interval = values.interval ? Number(values.interval) : DEFAULT_INTERVAL_SECONDS
+
+    if (!Number.isFinite(interval) || interval <= 0) {
+      fail(`--interval must be a positive number of seconds, got "${values.interval}"`)
+    }
+
+    watch(project, interval)
+    return
+  }
+
+  const state = aggregate(project)
+  process.stdout.write(`${renderFrame(state, process.stdout.columns || 120).join('\n')}\n`)
+}
+
+main()

--- a/alpha-projs/agent-dashboard/package.json
+++ b/alpha-projs/agent-dashboard/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "agent-dashboard",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "bin": { "agent-dashboard": "./cli.mjs" },
+  "scripts": {
+    "start": "node cli.mjs",
+    "watch": "node cli.mjs --watch"
+  }
+}

--- a/public/guides/agent-dashboard/board.svg
+++ b/public/guides/agent-dashboard/board.svg
@@ -1,0 +1,39 @@
+<svg viewBox="0 0 1320 330" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="board-title">
+  <title id="board-title">The agent dashboard CLI rendering a live board in a terminal: one stale working child and three Child: workspaces that never reported.</title>
+  <style>
+    text { font-family: "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace; font-size: 13px; white-space: pre; }
+    .bg { fill: #101216; }
+    .chrome { fill: #1a1d23; }
+    .fg { fill: #d6d8dd; }
+    .dim { fill: #6b7280; }
+    .bold { font-weight: 700; }
+    .red { fill: #f0555d; }
+    .yellow { fill: #d9a441; }
+    .green { fill: #4cbb6c; }
+    .cyan { fill: #4db8c4; }
+    .blue { fill: #5c8ef0; }
+  </style>
+
+  <rect class="bg" x="0" y="0" width="1320" height="330" rx="10" />
+  <rect class="chrome" x="0" y="0" width="1320" height="34" rx="10" />
+  <rect class="chrome" x="0" y="20" width="1320" height="14" />
+  <circle cx="22" cy="17" r="6" fill="#f0555d" />
+  <circle cx="42" cy="17" r="6" fill="#d9a441" />
+  <circle cx="62" cy="17" r="6" fill="#4cbb6c" />
+  <text class="dim" x="88" y="21">agent-dashboard — node cli.mjs --watch</text>
+
+  <text x="24" y="66"><tspan class="fg bold">leoncheng57.github.io</tspan><tspan class="dim">  base main</tspan></text>
+  <text x="24" y="88"><tspan class="fg">4 children  0 blocked  </tspan><tspan class="red bold">1 stale</tspan><tspan class="fg">  0 done</tspan><tspan class="dim">  5:10:49 PM</tspan></text>
+
+  <text class="dim bold" x="24" y="126">CHILD               PHASE      AGE  BRANCH                              CI    PR     WORKSPACE     NOTES</text>
+
+  <text x="24" y="152"><tspan class="fg">gr-screenshot       </tspan><tspan class="cyan">working    </tspan><tspan class="red bold">8h </tspan><tspan class="fg"> alpha-projs/gmail-reader-sc… </tspan><tspan class="green">+1</tspan><tspan class="fg">/</tspan><tspan class="yellow">-2</tspan><tspan class="fg">  </tspan><tspan class="green">pass</tspan><tspan class="fg">  </tspan><tspan class="blue">#191</tspan><tspan class="dim">   -             </tspan><tspan class="dim">Installing deps and studying GA…</tspan></text>
+
+  <text x="24" y="178"><tspan class="fg">Notif CLI           </tspan><tspan class="yellow bold">no-report  </tspan><tspan class="dim">-    -                                   -     -      </tspan><tspan class="fg">workspace:45  </tspan><tspan class="yellow">no .agent-status.json found for this workspace</tspan></text>
+
+  <text x="24" y="204"><tspan class="fg">Notif Plugin Core   </tspan><tspan class="yellow bold">no-report  </tspan><tspan class="dim">-    -                                   -     -      </tspan><tspan class="fg">workspace:44  </tspan><tspan class="yellow">no .agent-status.json found for this workspace</tspan></text>
+
+  <text x="24" y="230"><tspan class="fg">Selfhost Pilot      </tspan><tspan class="yellow bold">no-report  </tspan><tspan class="dim">-    -                                   -     -      </tspan><tspan class="fg">workspace:46  </tspan><tspan class="yellow">no .agent-status.json found for this workspace</tspan></text>
+
+  <text class="dim" x="24" y="282">refreshing every 5s - ctrl-c to exit</text>
+</svg>

--- a/public/guides/agent-dashboard/collector-flow.svg
+++ b/public/guides/agent-dashboard/collector-flow.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 600" role="img" aria-labelledby="title description">
+  <title id="title">Status reporting and collection for parallel agent workers</title>
+  <desc id="description">Three worker sessions each write an agent status JSON file at the root of their own Git worktree on every phase change. A local collector polls those files, merges them into one list, and serves both a board with one row per worker and a JSON feed at slash api slash state. The collector only reads; it never writes back to the workers.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#101827"/>
+      <stop offset="1" stop-color="#080d16"/>
+    </linearGradient>
+    <linearGradient id="worker" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#284d69"/>
+      <stop offset="1" stop-color="#1b334b"/>
+    </linearGradient>
+    <linearGradient id="collector" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#2f5d4a"/>
+      <stop offset="1" stop-color="#1d3b30"/>
+    </linearGradient>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0l10 5-10 5z" fill="#8ea6ba"/>
+    </marker>
+    <style>
+      .sans { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+      .eyebrow { fill: #7dd3b0; font-size: 15px; font-weight: 750; letter-spacing: 2px; }
+      .heading { fill: #f4f0e8; font-size: 30px; font-weight: 760; }
+      .label { fill: #f4f0e8; font-size: 19px; font-weight: 720; }
+      .copy { fill: #afbdca; font-size: 14px; }
+      .tiny { fill: #899aab; font-size: 12px; }
+      .code { fill: #9fd8c4; font-size: 13px; }
+      .flow { fill: none; stroke: #8ea6ba; stroke-width: 2.5; marker-end: url(#arrow); }
+      .serve { fill: none; stroke: #7dd3b0; stroke-width: 2.5; stroke-dasharray: 7 6; marker-end: url(#arrow); }
+    </style>
+  </defs>
+
+  <rect width="1000" height="600" rx="28" fill="url(#background)"/>
+  <text x="42" y="48" class="sans eyebrow">PARALLEL AGENT VISIBILITY</text>
+  <text x="42" y="87" class="sans heading">Workers report; the collector only reads</text>
+
+  <!-- Worker column headings -->
+  <text x="42" y="132" class="sans tiny">ONE WORKTREE PER WORKER</text>
+
+  <!-- Worker 1 -->
+  <rect x="42" y="148" width="280" height="104" rx="16" fill="url(#worker)" stroke="#3c6a8c" stroke-width="1.5"/>
+  <text x="62" y="180" class="sans label">worker A</text>
+  <text x="62" y="204" class="sans copy">phase: working</text>
+  <text x="62" y="232" class="mono code">.agent-status.json</text>
+
+  <!-- Worker 2 -->
+  <rect x="42" y="266" width="280" height="104" rx="16" fill="url(#worker)" stroke="#3c6a8c" stroke-width="1.5"/>
+  <text x="62" y="298" class="sans label">worker B</text>
+  <text x="62" y="322" class="sans copy">phase: blocked</text>
+  <text x="62" y="350" class="mono code">.agent-status.json</text>
+
+  <!-- Worker 3 -->
+  <rect x="42" y="384" width="280" height="104" rx="16" fill="url(#worker)" stroke="#3c6a8c" stroke-width="1.5"/>
+  <text x="62" y="416" class="sans label">worker C</text>
+  <text x="62" y="440" class="sans copy">phase: pr-open</text>
+  <text x="62" y="468" class="mono code">.agent-status.json</text>
+
+  <text x="42" y="520" class="sans tiny">Rewritten on every phase change, with updated_at.</text>
+  <text x="42" y="542" class="sans tiny">Gitignored: it describes a run, not the branch.</text>
+
+  <!-- Arrows from workers to collector -->
+  <path class="flow" d="M330 200 L 420 280"/>
+  <path class="flow" d="M330 318 L 420 318"/>
+  <path class="flow" d="M330 436 L 420 356"/>
+  <text x="352" y="258" class="sans tiny">poll</text>
+
+  <!-- Collector -->
+  <rect x="428" y="248" width="212" height="140" rx="16" fill="url(#collector)" stroke="#3f7a63" stroke-width="1.5"/>
+  <text x="452" y="288" class="sans label">collector</text>
+  <text x="452" y="314" class="sans copy">scan roots</text>
+  <text x="452" y="336" class="sans copy">merge + sort</text>
+  <text x="452" y="358" class="sans copy">flag stale rows</text>
+  <text x="452" y="380" class="sans tiny">read-only</text>
+
+  <!-- Arrows from collector to outputs -->
+  <path class="serve" d="M648 296 L 726 232"/>
+  <path class="serve" d="M648 340 L 726 404"/>
+
+  <!-- Board output -->
+  <rect x="734" y="160" width="224" height="140" rx="16" fill="#111827" stroke="#1f2a3c" stroke-width="1.5"/>
+  <text x="756" y="196" class="sans label">board</text>
+  <text x="756" y="222" class="sans copy">one row per worker</text>
+  <rect x="756" y="238" width="180" height="10" rx="5" fill="#f87171"/>
+  <rect x="756" y="256" width="180" height="10" rx="5" fill="#334155"/>
+  <rect x="756" y="274" width="180" height="10" rx="5" fill="#334155"/>
+
+  <!-- API output -->
+  <rect x="734" y="336" width="224" height="132" rx="16" fill="#111827" stroke="#1f2a3c" stroke-width="1.5"/>
+  <text x="756" y="372" class="sans label">JSON feed</text>
+  <text x="756" y="398" class="mono code">/api/state</text>
+  <text x="756" y="424" class="sans copy">counts + workers[]</text>
+  <text x="756" y="448" class="sans tiny">for scripts and waits</text>
+
+  <text x="734" y="520" class="sans tiny">Nothing is written back to a worker,</text>
+  <text x="734" y="542" class="sans tiny">so the board is always safe to run.</text>
+</svg>

--- a/src/content/guides/agent-dashboard/guide.md
+++ b/src/content/guides/agent-dashboard/guide.md
@@ -1,0 +1,368 @@
+---
+title: "Watching Parallel Agents with a Status Protocol and a Local Board"
+description: "Give every worker agent a status file it rewrites on each phase change, then read those files as one live terminal board that shows who is working, who is blocked, and who has gone quiet."
+updatedAt: "2026-08-14"
+publishedAt: "2026-08-14"
+audience: "Engineers already running several coding agents at once who cannot tell, at a glance, which ones are stuck."
+tags:
+  - AI
+  - workflow
+  - observability
+---
+
+# Watching Parallel Agents with a Status Protocol and a Local Board
+
+Running several coding agents at the same time scales the work but not the visibility. Once four or five workers are going, the only way to know where they are is to walk the terminals one by one, and a worker that quietly blocked on a missing credential looks exactly like a worker that is still thinking.
+
+This guide fixes that with two pieces. The first is a **reporting protocol**: every worker rewrites a small `.agent-status.json` at the root of its own worktree on every phase change. The second is a **CLI board**: a local, zero-dependency Node command that collects those files, joins them with Git, GitHub, and cmux state, and prints one row per worker — as a one-shot table, a live `--watch` board in a spare terminal, or `--json` for other tools.
+
+![The live board in a terminal: a header counting children, blocked, stale, and done, then one row per child showing phase, age, branch with ahead/behind counts, CI state, pull request number, cmux workspace, and a one-line note.](/guides/agent-dashboard/board.svg "One row per child, sorted worst-first. The stale row and the no-report rows are the ones that matter.")
+
+The protocol is the part that matters. It is useful on its own, before any dashboard exists, because it converts "go look at five terminals" into "read five small files". The board is just the nicest way to read them.
+
+This guide is a companion to [Running Parallel Coding Agents with a Manager and Workers](/guides/manager-worker-parallel-agents), which covers how the workers get launched in the first place. You do not need to have read it, but the vocabulary — manager, worker, worktree, contract — comes from there. Everything is on this one page: the flow, the protocol, the manager activation block, the CLI, and the reference.
+
+## Why a terminal board
+
+This board exists for one specific moment: an agent session you are working in becomes a **manager**, fans the work out to several **child** sessions, and you suddenly have four or five terminals doing things you can no longer see at once.
+
+The flow it supports has four steps:
+
+1. During a session, you decide the work should be parallelized. The session becomes the manager.
+2. You paste the manager activation block (next section) so the session knows the conventions: one child per Git worktree, one cmux workspace per child, a status file each child rewrites as it works.
+3. The manager launches the children, then spawns this CLI in a spare terminal with `--watch`. One live table, one row per child.
+4. When the run is over, you close that terminal yourself. The board holds no state; nothing else notices.
+
+The board is a CLI on purpose. The children are terminals, the manager is a terminal, and a watcher belongs next to them — one more pane in the same multiplexer, not a browser tab that drifts behind the work. It also means the machine-readable form is one flag away: `--json` is the same aggregation the table prints.
+
+### Why not just look at the terminals?
+
+Reading a child's TUI from outside is a guess dressed up as monitoring:
+
+- A quiet terminal is ambiguous. A long test run, deep model thinking, a prompt waiting for input, and a dead process all look identical from the outside.
+- Scrollback is lossy. The line that explained the failure scrolled away an hour ago.
+- Output formats change. The moment the agent's TUI redraws differently, the scraper reads noise.
+- It does not scale. Five children means five panes to walk, every few minutes, forever.
+
+The same is true of the other indirect signals. Processes prove existence, not progress. Git proves commits, not work in progress.
+
+| Approach | Tells you | Fails when |
+| --- | --- | --- |
+| Watch processes | A process exists | The agent is alive but stuck waiting for input |
+| Watch Git | Commits landed | Work is in progress and uncommitted |
+| Scrape terminals | Whatever was printed | Output format changes, or scrollback is lost |
+| Child reports | The phase the child believes it is in | The child dies — which the timestamp then exposes |
+
+### Poll to push
+
+The fix is to stop observing and start requiring reports. Every child rewrites a small status file at the root of its own worktree on every phase change. That one rule converts "walk five terminals" into "read five small files" — and converts a manager that polls into a manager that gets told.
+
+Two failure modes get first-class treatment, because they are the ones that silently eat an afternoon:
+
+- **Blocked children announce themselves.** A child that hits a missing credential writes `blocked` with a reason and stops, instead of burning tokens guessing.
+- **Silent children get exposed.** Every report carries a timestamp; a row that has not been rewritten in fifteen minutes is flagged stale. A child that died mid-task looks exactly like this — which is the point.
+
+And to be clear about scope: this is not a scheduler or a supervisor — it reads and never starts, stops, or nudges a child. It is not remote monitoring — it reads local files on one machine, so there is nothing to deploy. And it is not a transcript viewer — it never parses agent output. Children report; they are not scraped.
+
+## The status protocol
+
+The protocol is one rule: **on every phase change, a child rewrites a small JSON file at the root of its own worktree.** Everything else on this page reads that file.
+
+### The file
+
+The file is `.agent-status.json`, written at the root of the child's worktree:
+
+```json
+{
+  "task": "agent-dashboard",
+  "phase": "working",
+  "branch": "guides/agent-dashboard",
+  "pr_url": null,
+  "summary": "building the CLI board",
+  "blockers": [],
+  "updated_at": "2026-08-14T12:35:00Z"
+}
+```
+
+It is deliberately flat: one object per child, no nesting, no history. The reader should never have to understand a transcript to answer "what is everyone doing right now".
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `task` | string | Stable task identifier, usually the issue slug |
+| `phase` | string | Current phase, from the vocabulary below |
+| `branch` | string | Branch the child owns |
+| `pr_url` | string or null | Draft PR once one exists |
+| `summary` | string | One line of human context for the current phase |
+| `blockers` | string array | Empty unless `phase` is `blocked` |
+| `updated_at` | ISO 8601 string | Rewritten on every transition |
+
+Two fields do the real work. `phase` is what you scan for; `updated_at` is what makes silence detectable.
+
+### One phase vocabulary
+
+A shared vocabulary is what lets one board describe children doing unrelated jobs. Six phases cover the normal path, and one covers trouble:
+
+```text
+assigned -> working -> verifying -> pushed -> pr-open -> done
+                 \
+                  `-> blocked (from any phase, and back again)
+```
+
+| Phase | Means |
+| --- | --- |
+| `assigned` | Contract received, nothing written yet |
+| `working` | Implementing |
+| `verifying` | Running lint, tests, build |
+| `pushed` | Branch pushed, no pull request yet |
+| `pr-open` | Draft pull request open, awaiting review |
+| `done` | Work handed off; the child is idle but resumable |
+| `blocked` | Cannot proceed; `blockers` says why |
+
+Keep the list short and closed. A vocabulary that grows per task stops being scannable, which is the only thing it was for.
+
+`blocked` is the phase that earns the whole protocol. A child that hits a missing credential, an ambiguous requirement, or a failing dependency writes the reason and stops, instead of burning tokens or silently guessing.
+
+### Keep the file out of Git
+
+The status file describes a local run, not the branch, so it must never land in a commit. Add it to `.gitignore` once, in the shared repository:
+
+```bash
+echo '.agent-status.json' >> .gitignore
+```
+
+Ignoring it centrally also means a child cannot accidentally include it in a diff, which would otherwise produce a pull request whose contents change every time the agent changes phase.
+
+### Mirror the phase where you already look
+
+The file is for tooling. If your terminal multiplexer can show a per-tab status, mirror the phase there too, so the information is present in the place you are already looking:
+
+```bash
+cmux set-status agent "$PHASE" --icon "bolt.fill"
+```
+
+This is optional and entirely substitutable — a tmux window rename does the same job. The file remains the source of truth; the tab is a convenience.
+
+### Turn a session into a manager
+
+The protocol only happens if the manager demands it, so the whole arrangement is packaged as one block you paste into any agent session the moment you decide it should become a manager. It carries the conventions, the assignment template, the reporting rule, and the board:
+
+```text
+MANAGER MODE. From now on, this session is a MANAGER coordinating parallel
+CHILD agent sessions. You coordinate, review, and merge; children implement.
+
+Conventions
+- One child = one git worktree = one cmux workspace.
+  git worktree add -b <branch> ../<repo>.worktrees/<branch> main
+- Child workspaces are named "Child: <Task>" and created in this workspace's
+  group, unfocused. Children run a persistent `opencode --auto -m <model>` TUI
+  so they can be chatted with after their task finishes.
+- Children NEVER push the main branch. They push their own branch (and open a
+  draft PR when the repo uses PRs).
+
+Every child assignment prompt must include:
+1. Identity + scope: "You are the <task> worker, working ONLY in this worktree
+   on branch <branch>."
+2. Autonomy: implement, test, commit, push -u origin <branch>; never push main.
+3. Reporting (verbatim):
+   - On every phase change, rewrite .agent-status.json at the worktree root:
+     {"task": "<task>", "phase": "<phase>", "branch": "<branch>",
+      "pr_url": <url|null>, "summary": "<one line>", "blockers": [],
+      "updated_at": "<ISO 8601 UTC>"}
+   - Phases: assigned, working, verifying, pushed, pr-open, done. Use blocked
+     at any point, with blockers explaining why.
+   - Never skip the write. A stale file is read as a dead worker.
+   - Mirror the phase with `cmux set-status agent "<phase>"` and send
+     `cmux notify` when done or blocked.
+4. The verification gate to run before every commit (lint, tests, build).
+5. "Print a short summary and stay available for follow-up instructions."
+
+Manager rules
+- Monitor children through their status files and pushed branches. Never
+  screen-scrape a child's TUI; read a screen only to debug a stuck child.
+- Merge one branch at a time with full verification between merges.
+- Immediately after launching children, spawn the live board in a spare
+  terminal pane, unfocused:
+    cmux new-pane --type terminal --direction right --focus false
+  then run in it:
+    node <site-repo>/alpha-projs/agent-dashboard/cli.mjs --watch
+  The user closes that pane manually when the run is over; never close it
+  yourself.
+```
+
+Adjust the two placeholders — the model and the path to a checkout of [the CLI](https://github.com/leoncheng57/leoncheng57.github.io/tree/main/alpha-projs/agent-dashboard) — and the block is complete. The `cmux` lines assume [cmux](https://cmux.io); under tmux, substitute a `split-window` and a window rename.
+
+With the protocol in place you already have something useful: `cat ../*/.agent-status.json` answers the question across every worktree. The CLI replaces that with a board.
+
+## Run the CLI
+
+The CLI is a single file with no dependencies. From any directory inside the repository whose children you want to watch:
+
+```bash
+node <site-repo>/alpha-projs/agent-dashboard/cli.mjs            # one-shot table
+node <site-repo>/alpha-projs/agent-dashboard/cli.mjs --watch    # live board, redrawn every 5s
+node <site-repo>/alpha-projs/agent-dashboard/cli.mjs --json     # the same state, for scripts and agents
+```
+
+There is no install step and, in the common case, no config: the project is inferred from the directory you run it in. The main clone is found with `git rev-parse --git-common-dir` (so running from inside a worktree works), the base branch from `origin/HEAD`, the children from the sibling `<repo>.worktrees/*` directory, and the GitHub repo from the `origin` remote. A config file overrides any of that — see the reference below.
+
+### Reading the board
+
+```text
+leoncheng57.github.io  base main
+4 children  0 blocked  1 stale  0 done  5:10:49 PM
+
+CHILD             PHASE      AGE  BRANCH                          CI    PR    WORKSPACE     NOTES
+gr-screenshot     working    8h   alpha-projs/gmail-reader-sc… +1/-2  pass  #191  -        Installing deps and studying GA dashboard screenshot
+Notif CLI         no-report  -    -                               -     -    workspace:45  no .agent-status.json found for this workspace
+Notif Plugin Core no-report  -    -                               -     -    workspace:44  no .agent-status.json found for this workspace
+Selfhost Pilot    no-report  -    -                               -     -    workspace:46  no .agent-status.json found for this workspace
+```
+
+One row per child, sorted worst-first — stale rows, then blocked, then the working phases, with `done` at the bottom. The top of the table is always the shortest description of what still needs attention. In the capture above, all four rows are demanding it: a child that claims `working` but has not reported for eight hours is almost certainly dead, and three `Child:` workspaces exist that never reported at all.
+
+| Column | Source | Meaning |
+| --- | --- | --- |
+| CHILD | status file | The `task`, falling back to the worktree directory name |
+| PHASE | status file | The phase the child last reported, colored by severity |
+| AGE | status file | Time since `updated_at`; red once it crosses the stale threshold |
+| BRANCH | status file + Git | The child's branch, with `+ahead/-behind` counted against the base branch |
+| CI | GitHub | The status-check rollup of the branch's newest pull request |
+| PR | GitHub | Pull request number — dim while draft, blue when open, purple when merged |
+| WORKSPACE | cmux | The cmux workspace the child's worktree lives in |
+| NOTES | status file | Blockers in red; otherwise the child's one-line summary |
+
+Two synthetic phases can appear alongside the reported ones. `no-report` marks a `Child:` cmux workspace that has no status file — a child that was created but never reported, which is precisely the child that must not be invisible. `invalid` marks a status file that would not parse, usually one caught mid-write; the row stays on the board with the parse error in NOTES.
+
+`cmux` and `gh` are optional. When either is missing or fails, its columns show `-` and the reason appears once, as a quiet note under the table. Only Git and the status files are required.
+
+### The live board
+
+`--watch` renders the same table in the alternate screen buffer and redraws it on an interval (`--interval <seconds>`, default 5). Ctrl-C restores the terminal exactly as it was — the board holds no state, so quitting and relaunching it costs nothing.
+
+In the four-step flow above, the manager spawns this right after launching the children, in a spare pane it does not focus:
+
+```bash
+cmux new-pane --type terminal --direction right --focus false
+# then, in that pane:
+node <site-repo>/alpha-projs/agent-dashboard/cli.mjs --watch
+```
+
+You glance at the board while the run is going, chat with the manager or any child in their own panes, and close the board's pane yourself when the run is over. Nothing depends on it being up; it is a window onto files, not a participant.
+
+### The machine-readable board
+
+`--json` prints the exact aggregation the table renders — children, counts, sources, notes — and exits. It exists so the board is not only for eyes: a manager session can read it directly instead of globbing the status files itself, and any other tool can build on the same view of the run. The schema is in the reference below.
+
+## Reference
+
+### Flags
+
+| Flag | Meaning |
+| --- | --- |
+| `--watch` | Live board in the alternate screen buffer, restored cleanly on Ctrl-C |
+| `--json` | Print the aggregated state as JSON and exit |
+| `--config <path>` | Use this config file instead of auto-detection |
+| `--project <name>` | Select one project from a multi-project config |
+| `--interval <seconds>` | Redraw interval for `--watch` (default 5) |
+| `--help` | Usage |
+
+`NO_COLOR` in the environment, or piping stdout, disables color.
+
+### Auto-detection
+
+With no config file, the project is inferred from the current directory:
+
+| Value | Derived from |
+| --- | --- |
+| `root` | `git rev-parse --git-common-dir`, so running from inside a linked worktree resolves to the main clone |
+| `name` | The basename of `root` |
+| `mainBranch` | `origin/HEAD`, falling back to `main` |
+| `worktrees` | `<parent of root>/<name>.worktrees/*` — the sibling-directory layout the manager conventions use |
+| `github` | Owner and repo parsed from the `origin` remote, SSH or HTTPS form |
+
+If the current directory is not inside a Git repository, the CLI refuses to guess and asks for `--config`.
+
+### Config keys
+
+`agent-dashboard.config.json`, created by copying `agent-dashboard.config.example.json`, found in the current directory or next to `cli.mjs`. The file is gitignored because its values are local paths; only the example is committed. A config that exists but does not parse is a hard error — a silently ignored config is worse than a refusal to start.
+
+| Key | Type | Meaning |
+| --- | --- | --- |
+| `name` | string | Project label shown in the header |
+| `root` | string | Path to the main clone |
+| `mainBranch` | string | Base branch for ahead/behind counts |
+| `worktrees` | string | Directory of child worktrees; a trailing `/*` scans its subdirectories |
+| `github` | `{ "owner", "repo" }` | Repository for `gh pr list`; omit to use `gh`'s own resolution |
+| `staleAfterSeconds` | number | Age past which a row is flagged stale (default 900); `done` rows are exempt |
+
+Anything the config leaves out falls back to auto-detection, so a config can be a single overridden key. To track several projects, wrap them in a `projects` array and select one with `--project <name>`.
+
+### The `--json` response
+
+```json
+{
+  "generatedAt": "2026-08-14T20:41:07.201Z",
+  "project": {
+    "name": "leoncheng.dev",
+    "root": "/Users/you/code/leoncheng57.github.io",
+    "mainBranch": "main",
+    "worktrees": "/Users/you/code/leoncheng57.github.io.worktrees/*",
+    "github": { "owner": "leoncheng57", "repo": "leoncheng57.github.io" },
+    "source": "auto-detected"
+  },
+  "staleAfterSeconds": 900,
+  "counts": { "total": 2, "blocked": 0, "stale": 1, "done": 1 },
+  "sources": { "cmux": { "available": true }, "gh": { "available": true } },
+  "notes": [],
+  "children": [
+    {
+      "id": "agent-dashboard",
+      "worktree": "/Users/you/code/leoncheng57.github.io.worktrees/agent-dashboard",
+      "task": "agent-dashboard",
+      "phase": "pr-open",
+      "branch": "guides/agent-dashboard",
+      "prUrl": "https://github.com/leoncheng57/leoncheng57.github.io/pull/192",
+      "summary": "draft PR open, awaiting review",
+      "blockers": [],
+      "updatedAt": "2026-08-14T20:37:00Z",
+      "ageSeconds": 247,
+      "stale": false,
+      "note": null,
+      "git": { "available": true, "ahead": 7, "behind": 5, "base": "origin/main" },
+      "ci": { "state": "passing", "available": true },
+      "pr": { "number": 192, "state": "OPEN", "isDraft": true, "url": "https://…/pull/192" },
+      "cmux": { "ref": "workspace:39", "title": "Child: Agent Dashboard 2" }
+    }
+  ]
+}
+```
+
+Top level: `generatedAt` (when this response was built), `project` (the resolved project; `source` is `auto-detected` or the config path), `staleAfterSeconds` (echoed so a consumer can explain its own coloring), `counts` (`total`, `blocked`, `stale`, `done`), `sources` (whether `cmux` and `gh` answered on this pass), `notes` (non-fatal degradations, such as `gh not on PATH`), and `children` (one entry per child, pre-sorted worst-first).
+
+Per child: `id` (worktree directory name), `worktree` (absolute path the status file was read from), the status-file fields passed through (`task`, `phase`, `branch`, `summary`, `blockers`, with `pr_url` camel-cased to `prUrl`), `updatedAt`/`ageSeconds` (with the age derived at read time), `stale` (`ageSeconds > staleAfterSeconds` and phase is not `done`), `note` (set on synthetic rows), `git` (`{ available, ahead, behind, base }`), `ci` (`{ state, available }` — `passing`, `failing`, `pending`, `unknown`, or `none`), `pr` (`{ number, state, isDraft, url }`), and `cmux` (`{ ref, title }` of the matched `Child:` workspace).
+
+Every row has the same keys whether or not its file parsed, so consumers never feature-detect. `snake_case` on disk is for humans writing the file by hand; `camelCase` in the output is for the clients reading it.
+
+### Extending
+
+The CLI separates its sources, which is where extensions belong:
+
+- `readStatusFile(directory, …)` decides what a child is. Accept a second file format here by mapping it into the same shape, rather than teaching the renderer a second schema.
+- `readCmuxWorkspaces()` / `readPullRequests()` / `readAheadBehind()` each degrade independently. A new source — a CI system, a different multiplexer — should follow the same pattern: return `available: false` with a one-line note instead of throwing.
+- Every subprocess goes through one cached `run()` helper (5-second TTL, 10-second timeout), so a new source inherits the same cost controls.
+
+The rule to keep is that the CLI reads and never writes. As soon as it can nudge a child, a bug in it can corrupt a run, and its job is to be the thing you trust when everything else is uncertain.
+
+### Checklist
+
+- [ ] `.agent-status.json` added to the repository `.gitignore`
+- [ ] Reporting rule present in every child contract
+- [ ] Worktrees at `../<repo>.worktrees/<branch>` so auto-detection finds them
+- [ ] `staleAfterSeconds` longer than your slowest normal verification step
+- [ ] Board left running in an unfocused pane for the whole run — and closed by you, not by the manager
+- [ ] Blocked rows treated as an interrupt, not a queue
+
+### Related reading
+
+- [Running Parallel Coding Agents with a Manager and Workers](/guides/manager-worker-parallel-agents) — how the children this watches are planned, launched, and reviewed
+- [The CLI source](https://github.com/leoncheng57/leoncheng57.github.io/tree/main/alpha-projs/agent-dashboard) — one file, no dependencies, vendored in this site's repository

--- a/src/features/blog/routes/blog-routes.test.tsx
+++ b/src/features/blog/routes/blog-routes.test.tsx
@@ -26,9 +26,9 @@ describe('blog routes', () => {
     ).toHaveAttribute('href', '/guides/manager-worker-parallel-agents')
     expect(
       screen.getByRole('link', {
-        name: /Worktrees, Remote Coding Agents, and Choosing the Right Kind of Isolation/i,
+        name: /Watching Parallel Agents with a Status Protocol and a Local Board/i,
       })
-    ).toHaveAttribute('href', '/blog/worktrees-vs-remote-coding-agents')
+    ).toHaveAttribute('href', '/guides/agent-dashboard')
   })
 
   it('renders the blog index route', () => {

--- a/src/features/guides/components/GuideCard.tsx
+++ b/src/features/guides/components/GuideCard.tsx
@@ -37,12 +37,16 @@ export default function GuideCard({ guide }: GuideCardProps): ReactElement {
 
         <p className={styles.cardMeta}>
           <span>updated {guide.updatedAt}</span>
-          <span className={styles.separator} aria-hidden="true">
-            ·
-          </span>
-          <span>
-            {guide.chapters.length} {guide.chapters.length === 1 ? 'chapter' : 'chapters'}
-          </span>
+          {guide.chapters.length > 0 ? (
+            <>
+              <span className={styles.separator} aria-hidden="true">
+                ·
+              </span>
+              <span>
+                {guide.chapters.length} {guide.chapters.length === 1 ? 'chapter' : 'chapters'}
+              </span>
+            </>
+          ) : null}
           <span className={styles.separator} aria-hidden="true">
             ·
           </span>

--- a/src/features/guides/content.test.ts
+++ b/src/features/guides/content.test.ts
@@ -136,7 +136,10 @@ title: "Second Chapter"
       expect(guide.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/)
       expect(guide.tags.length).toBeLessThanOrEqual(3)
       expect(guide.overview.length).toBeGreaterThan(0)
-      expect(guide.chapters.length).toBeGreaterThan(0)
+      // A guide is either multi-chapter or a single substantial page.
+      if (guide.chapters.length === 0) {
+        expect(guide.readingTimeMinutes).toBeGreaterThan(3)
+      }
 
       for (const chapter of guide.chapters) {
         expect(chapter.title).toBeTruthy()

--- a/src/features/guides/routes/GuideOverviewRoute.tsx
+++ b/src/features/guides/routes/GuideOverviewRoute.tsx
@@ -32,12 +32,16 @@ export default function GuideOverviewRoute(): ReactElement {
         {guide.audience ? <p className={styles.audience}>{guide.audience}</p> : null}
         <p className={styles.heroMeta}>
           <span>Last reviewed {guide.updatedAt}</span>
-          <span className={styles.metaSeparator} aria-hidden="true">
-            ·
-          </span>
-          <span>
-            {guide.chapters.length} {guide.chapters.length === 1 ? 'chapter' : 'chapters'}
-          </span>
+          {guide.chapters.length > 0 ? (
+            <>
+              <span className={styles.metaSeparator} aria-hidden="true">
+                ·
+              </span>
+              <span>
+                {guide.chapters.length} {guide.chapters.length === 1 ? 'chapter' : 'chapters'}
+              </span>
+            </>
+          ) : null}
           <span className={styles.metaSeparator} aria-hidden="true">
             ·
           </span>
@@ -50,9 +54,11 @@ export default function GuideOverviewRoute(): ReactElement {
               Start reading &rarr;
             </Link>
           ) : null}
-          <a href="#guide-contents" className={styles.secondaryCta}>
-            Contents
-          </a>
+          {guide.chapters.length > 0 ? (
+            <a href="#guide-contents" className={styles.secondaryCta}>
+              Contents
+            </a>
+          ) : null}
         </div>
       </header>
 

--- a/src/features/guides/routes/guides-route.test.tsx
+++ b/src/features/guides/routes/guides-route.test.tsx
@@ -6,6 +6,9 @@ import App from '../../../App'
 
 const GUIDE_TITLE = 'Running Parallel Coding Agents with a Manager and Workers'
 const GUIDE_PATH = '/guides/manager-worker-parallel-agents'
+const DASHBOARD_TITLE =
+  'Watching Parallel Agents with a Status Protocol and a Local Board'
+const DASHBOARD_PATH = '/guides/agent-dashboard'
 
 describe('guides index route', () => {
   it('lists published guides as cards with chapter previews', () => {
@@ -19,12 +22,29 @@ describe('guides index route', () => {
 
     expect(screen.getByRole('link', { name: GUIDE_TITLE })).toHaveAttribute('href', GUIDE_PATH)
     expect(screen.getByText(/5 chapters/)).toBeInTheDocument()
-    expect(screen.getByText(/updated 2026-/)).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /read guide/ })).toHaveAttribute('href', GUIDE_PATH)
+    expect(screen.getAllByText(/updated 2026-/).length).toBeGreaterThan(0)
+    expect(screen.getAllByRole('link', { name: /read guide/ })[0]).toHaveAttribute(
+      'href',
+      expect.stringMatching(/^\/guides\//)
+    )
 
     // The card previews the first chapters without listing all of them.
     expect(screen.getByText('Plan the work and set up workers')).toBeInTheDocument()
     expect(screen.getByText(/\+2 more/)).toBeInTheDocument()
+  })
+
+  it('lists a single-page guide without a chapter count', () => {
+    render(
+      <MemoryRouter initialEntries={['/guides']}>
+        <App />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByRole('link', { name: DASHBOARD_TITLE })).toHaveAttribute(
+      'href',
+      DASHBOARD_PATH
+    )
+    expect(screen.queryByText(/0 chapters/)).not.toBeInTheDocument()
   })
 
   it('stays on the main site chrome, like the apps index', () => {

--- a/src/features/repo/routes/repo-routes.test.tsx
+++ b/src/features/repo/routes/repo-routes.test.tsx
@@ -84,7 +84,7 @@ describe('repo subpages', () => {
     ).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /read guide/ })).toHaveAttribute(
       'href',
-      '/guides/manager-worker-parallel-agents'
+      '/guides/agent-dashboard'
     )
     expect(
       screen.getByRole('heading', { level: 3, name: 'Still taking shape' })

--- a/src/routes/home-route.test.tsx
+++ b/src/routes/home-route.test.tsx
@@ -17,16 +17,16 @@ describe('home route recent work', () => {
     expect(cards).toHaveLength(6)
     expect(cards.map((card) => card.getAttribute('href'))).toEqual([
       '/guides/manager-worker-parallel-agents',
+      '/guides/agent-dashboard',
       '/tuzi/',
       '/georgies-board-game-nights',
       '/sub-wait',
       '/workout-lab',
-      '/blog/worktrees-vs-remote-coding-agents',
     ])
     expect(within(recentWork).getAllByText('Project')).toHaveLength(1)
     expect(within(recentWork).getAllByText('App')).toHaveLength(3)
-    expect(within(recentWork).getAllByText('Blog')).toHaveLength(1)
-    expect(within(recentWork).getAllByText('Guide')).toHaveLength(1)
+    expect(within(recentWork).queryByText('Blog')).not.toBeInTheDocument()
+    expect(within(recentWork).getAllByText('Guide')).toHaveLength(2)
     expect(within(recentWork).getAllByText('Alpha')).toHaveLength(1)
     expect(within(recentWork).getAllByText('Beta')).toHaveLength(2)
   })


### PR DESCRIPTION
Stacked on #175 (`blog/manager-worker-agents-158-v2`) — review that first; this PR's diff is only the two commits below.

Companion to the manager-worker guide. That one covers how parallel workers get launched; this one covers how you see what they are doing once four or five are running.

## What is here

**A local status collector** (`alpha-projs/agent-dashboard`). Workers already write `.agent-status.json` at the root of their own worktree on every phase change — this adds the reader. Zero npm dependencies, so `node server.mjs` is the whole setup. It scans the configured roots, merges the files, sorts stale and blocked rows to the top, and serves a board plus `/api/state`. Local-only for the same reason as the GA dashboard: it reports on worktrees on one laptop.

**A four-chapter guide** at `/guides/agent-dashboard`:

1. The status protocol — the file, the phase vocabulary, the contract rule
2. Run the collector — copy the config, start it, confirm it is finding workers
3. Read the board — what each column means, row ordering, reading `/api/state`
4. Reference — config keys, response schema, extending with new sources

The alpha projs index gets a card, and the existing detail page is updated: it previously said there was no code to clone yet.

## Note for review

Home "Recent work" is a strict six-newest cut across guides, apps, and blogs. With a second guide, both guides now outrank the newest blog post, so **no Blog card is in range** — in a section titled "Latest across apps, blogs & guides". I updated the test to match rather than change the ranking, since that is a product call. Options if you want a blog always present: reserve a slot per type, or cap guides at one.

Two smaller test changes follow from there being a second guide:

- The guides index renders two cards now, so the ambiguous index-route assertions (`updated 2026-`, `read guide`) are scoped to a card looked up by title.
- The design-components specimen features whichever guide is newest, so it asserts the shape of the guide link instead of pinning one slug.

## Verification

- `npm run lint` clean
- `npm run test:run` — 45 files, 267 tests pass
- `npm run build` succeeds
- Collector exercised end to end against synthetic worktrees: healthy, blocked, stale, and malformed-JSON rows all render and sort correctly; missing roots degrade to a warning instead of a crash
- Every internal link in the guide checked against the running app; no `Chapter Not Found`, both assets served

```screenshots
/guides
/guides/agent-dashboard
/guides/agent-dashboard/read-the-board
/repo/alpha-projs/agent-dashboard
```