### PR TITLE
agent-dashboard: live board by default in a terminal

### DIFF
--- a/alpha-projs/agent-dashboard/README.md
+++ b/alpha-projs/agent-dashboard/README.md
@@ -12,8 +12,8 @@ worktrees on one laptop, so a static host has nothing to point it at.
 
 ```bash
 cd alpha-projs/agent-dashboard
-node cli.mjs            # one-shot table
-node cli.mjs --watch    # live board, redrawn every 5s, ctrl-c to exit
+node cli.mjs            # live board in a terminal, redrawn every 5s, ctrl-c to exit
+node cli.mjs --once     # one-shot table
 node cli.mjs --json     # aggregated state for scripts and agents
 ```
 
@@ -35,11 +35,15 @@ gmail-screenshot      done       42m  alpha-projs/gmail-r… +1/-1  pass  #191  
 Rows sort worst-first - stale, then by phase - so the top of the table is the
 shortest description of what still needs attention.
 
+In a terminal the live board is the default; piped output (`node cli.mjs | cat`)
+falls back to the one-shot table so scripts get plain text.
+
 ## Flags
 
 | Flag | Meaning |
 | --- | --- |
-| `--watch` | Live board in the alternate screen buffer, restored cleanly on ctrl-c |
+| `--once` | One-shot table, even in a terminal |
+| `--watch` | Live board, even when auto-detection says otherwise |
 | `--json` | Print the aggregated state and exit |
 | `--config <path>` | Use this config file instead of auto-detection |
 | `--project <name>` | Select one project from a multi-project config |

--- a/alpha-projs/agent-dashboard/cli.mjs
+++ b/alpha-projs/agent-dashboard/cli.mjs
@@ -33,12 +33,16 @@ const USAGE = `Agent dashboard - one row per child agent.
 Usage
   node cli.mjs [options]
 
+In a terminal the live board is the default. When stdout is piped the
+default is a one-shot table, so scripts get plain output.
+
 Options
-  --watch              Live full-screen board, redrawn on an interval
+  --once               One-shot table, even in a terminal
+  --watch              Live full-screen board, even when auto-detection says otherwise
   --json               Print the aggregated state as JSON and exit
   --config <path>      Config file to use instead of auto-detection
   --project <name>     Select one project from a multi-project config
-  --interval <seconds> Redraw interval for --watch (default ${DEFAULT_INTERVAL_SECONDS})
+  --interval <seconds> Redraw interval for the live board (default ${DEFAULT_INTERVAL_SECONDS})
   --help               Show this message
 
 With no config file the project is inferred from the current directory.`
@@ -48,6 +52,7 @@ function parseCliArgs(argv) {
     const { values } = parseArgs({
       args: argv,
       options: {
+        once: { type: 'boolean', default: false },
         watch: { type: 'boolean', default: false },
         json: { type: 'boolean', default: false },
         config: { type: 'string' },
@@ -57,6 +62,11 @@ function parseCliArgs(argv) {
       },
       strict: true,
     })
+
+    if (values.once && values.watch) {
+      fail(`--once and --watch contradict each other.\n\n${USAGE}`)
+    }
+
     return values
   } catch (error) {
     fail(`${error.message}\n\n${USAGE}`)
@@ -922,7 +932,12 @@ function main() {
     return
   }
 
-  if (values.watch) {
+  // The live board is the default where it makes sense: an interactive
+  // terminal. Piped output gets the one-shot table, because an alternate
+  // screen buffer is meaningless in a file or a pager.
+  const live = values.watch || (process.stdout.isTTY && !values.once)
+
+  if (live) {
     const interval = values.interval ? Number(values.interval) : DEFAULT_INTERVAL_SECONDS
 
     if (!Number.isFinite(interval) || interval <= 0) {

--- a/alpha-projs/agent-dashboard/package.json
+++ b/alpha-projs/agent-dashboard/package.json
@@ -6,6 +6,6 @@
   "bin": { "agent-dashboard": "./cli.mjs" },
   "scripts": {
     "start": "node cli.mjs",
-    "watch": "node cli.mjs --watch"
+    "once": "node cli.mjs --once"
   }
 }

--- a/src/content/guides/manager-worker-parallel-agents/05-watch-the-run.md
+++ b/src/content/guides/manager-worker-parallel-agents/05-watch-the-run.md
@@ -153,12 +153,12 @@ With the protocol in place you already have something useful: `cat ../*/.agent-s
 The CLI is a single file with no dependencies, [vendored in this site's repository](https://github.com/leoncheng57/leoncheng57.github.io/tree/main/alpha-projs/agent-dashboard). From any directory inside the repository whose workers you want to watch:
 
 ```bash
-node <site-repo>/alpha-projs/agent-dashboard/cli.mjs            # one-shot table
-node <site-repo>/alpha-projs/agent-dashboard/cli.mjs --watch    # live board, redrawn every 5s
+node <site-repo>/alpha-projs/agent-dashboard/cli.mjs            # live board, redrawn every 5s
+node <site-repo>/alpha-projs/agent-dashboard/cli.mjs --once     # one-shot table
 node <site-repo>/alpha-projs/agent-dashboard/cli.mjs --json     # the same state, for scripts and agents
 ```
 
-There is no install step and, in the common case, no config: the project is inferred from the directory you run it in. In the four-step flow this guide teaches, the manager spawns the `--watch` board right after launching the workers, in a spare pane it does not focus; you glance at it during the run and close it yourself when the run is over. Nothing depends on it being up — it is a window onto files, not a participant.
+In a terminal the live board is the default; piped output falls back to the one-shot table so scripts get plain text. There is no install step and, in the common case, no config: the project is inferred from the directory you run it in. In the four-step flow this guide teaches, the manager spawns the board right after launching the workers, in a spare pane it does not focus; you glance at it during the run and close it yourself when the run is over. Nothing depends on it being up — it is a window onto files, not a participant.
 
 ```text
 leoncheng57.github.io  base main
@@ -198,11 +198,12 @@ Two synthetic phases can appear alongside the reported ones. `no-report` marks a
 
 | Flag | Meaning |
 | --- | --- |
-| `--watch` | Live board in the alternate screen buffer, restored cleanly on Ctrl-C |
+| `--once` | One-shot table, even in a terminal |
+| `--watch` | Live board, even when piped detection would choose the table |
 | `--json` | Print the aggregated state as JSON and exit |
 | `--config <path>` | Use this config file instead of auto-detection |
 | `--project <name>` | Select one project from a multi-project config |
-| `--interval <seconds>` | Redraw interval for `--watch` (default 5) |
+| `--interval <seconds>` | Redraw interval for the live board (default 5) |
 | `--help` | Usage |
 
 With no config file, the project is inferred from the current directory: the main clone from `git rev-parse --git-common-dir` (so running inside a linked worktree works), the name from that directory's basename, the base branch from `origin/HEAD` (falling back to `main`), the workers from the sibling `<repo>.worktrees/*` directory, and the GitHub repo from the `origin` remote. If the current directory is not inside a Git repository, the CLI refuses to guess and asks for `--config`.


### PR DESCRIPTION
Interactive terminals now get the live board with no flags; piped stdout falls back to the one-shot table so scripts and agents keep getting plain text. Adds --once for an explicit table in a terminal; --watch stays accepted (now the auto-detected default) so every published command keeps working. --json unchanged. README + guide chapter updated.

Smokes: bare run in a TTY enters the alternate-screen board; `node cli.mjs | cat` prints the table; --once, --json, and the --once/--watch conflict guard verified.